### PR TITLE
Fix login data retrieval for new reservations/alquiler

### DIFF
--- a/dialog/AlquilerCreateDialog.java
+++ b/dialog/AlquilerCreateDialog.java
@@ -17,7 +17,7 @@ import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
 
-import com.pinguela.rentexpres.desktop.util.SessionManager;
+import com.pinguela.rentexpres.desktop.util.AppContext;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
 import com.pinguela.rentexpres.model.AlquilerDTO;
 import com.pinguela.rentexpres.model.EstadoAlquilerDTO;
@@ -170,9 +170,11 @@ public class AlquilerCreateDialog extends JDialog {
 		dto.setKmFinal(!txtKmFin.getText().isEmpty() ? Integer.parseInt(txtKmFin.getText().trim()) : 0);
 		dto.setCostetotal(!txtCosteTotal.getText().isEmpty() ? Integer.parseInt(txtCosteTotal.getText().trim()) : 0);
 		dto.setIdEstadoAlquiler(((EstadoAlquilerDTO) cmbEstado.getSelectedItem()).getId());
-		dto.setIdUsuario(SessionManager.getCurrentUserId());
-		return dto;
-	}
+                if (AppContext.getCurrentUser() != null) {
+                        dto.setIdUsuario(AppContext.getCurrentUser().getId());
+                }
+                return dto;
+        }
 
 	public void setIdUsuario(Integer id) {
 	}

--- a/dialog/ReservaCreateDialog.java
+++ b/dialog/ReservaCreateDialog.java
@@ -23,7 +23,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
-import com.pinguela.rentexpres.desktop.util.SessionManager;
+import com.pinguela.rentexpres.desktop.util.AppContext;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
 import com.pinguela.rentexpres.model.EstadoReservaDTO;
 import com.pinguela.rentexpres.model.ReservaDTO;
@@ -160,12 +160,14 @@ public class ReservaCreateDialog extends JDialog {
 		}
 	}
 
-	private ReservaDTO buildFromForm1() {
-		ReservaDTO dto = new ReservaDTO();
-		// … resto de campos …
-		dto.setIdUsuario(SessionManager.getCurrentUserId());
-		return dto;
-	}
+        private ReservaDTO buildFromForm1() {
+                ReservaDTO dto = new ReservaDTO();
+                // … resto de campos …
+                if (AppContext.getCurrentUser() != null) {
+                        dto.setIdUsuario(AppContext.getCurrentUser().getId());
+                }
+                return dto;
+        }
 
 	protected void onCrear() {
 


### PR DESCRIPTION
## Summary
- fix user id retrieval by using `AppContext` instead of unused `SessionManager`

## Testing
- `javac -cp "lib/calendar/jcalendar-1.4.jar:lib/middleware/RentExpres.jar" -d /tmp/classes dialog/AlquilerCreateDialog.java dialog/ReservaCreateDialog.java` *(fails: cannot find symbol)*

------
https://chatgpt.com/codex/tasks/task_e_68503d32c3a88331839c10b03b35a811