### PR TITLE
Refactor create dialogs and actions

### DIFF
--- a/controller/AbstractCreateAction.java
+++ b/controller/AbstractCreateAction.java
@@ -1,0 +1,61 @@
+package com.pinguela.rentexpres.desktop.controller;
+
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+import javax.swing.JDialog;
+
+import com.pinguela.rentexpres.desktop.dialog.ConfirmDialog;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
+import com.pinguela.rentexpres.desktop.util.SwingUtils;
+import com.pinguela.rentexpres.exception.RentexpresException;
+
+/**
+ * Generic action for dialogs that create entities.
+ */
+public abstract class AbstractCreateAction<T, D extends JDialog & ConfirmDialog<T>> extends AbstractAction {
+    private static final long serialVersionUID = 1L;
+
+    protected final Frame frame;
+    private final ActionCallback afterCreate;
+
+    protected AbstractCreateAction(Frame frame, ActionCallback afterCreate) {
+        this(null, frame, afterCreate);
+    }
+
+    protected AbstractCreateAction(String name, Frame frame, ActionCallback afterCreate) {
+        super(name);
+        this.frame = frame;
+        this.afterCreate = afterCreate;
+    }
+
+    /** Creates the dialog to obtain the DTO. */
+    protected abstract D createDialog();
+
+    /** Persists the new DTO. */
+    protected abstract void save(T dto) throws RentexpresException;
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        D dlg = createDialog();
+        dlg.setVisible(true);
+        if (dlg.isConfirmed()) {
+            try {
+                save(dlg.getValue());
+            } catch (RentexpresException ex) {
+                SwingUtils.showError(frame, "Error guardando: " + ex.getMessage());
+            }
+        }
+        if (afterCreate != null) {
+            afterCreate.execute();
+        }
+    }
+
+    /**
+     * For callers that used the old execute() method on concrete classes.
+     */
+    public void execute() throws RentexpresException {
+        actionPerformed(null);
+    }
+}

--- a/controller/ShowAlquilerCreateAction.java
+++ b/controller/ShowAlquilerCreateAction.java
@@ -8,29 +8,24 @@ import com.pinguela.rentexpres.exception.RentexpresException;
 import com.pinguela.rentexpres.model.AlquilerDTO;
 import com.pinguela.rentexpres.service.AlquilerService;
 
-public class ShowAlquilerCreateAction {
-    private final Frame frame;
+public class ShowAlquilerCreateAction extends AbstractCreateAction<AlquilerDTO, AlquilerCreateDialog> {
     private final AlquilerService alquilerService;
 
     public ShowAlquilerCreateAction(Frame frame, AlquilerService alquilerService) {
-        this.frame = frame;
+        super(frame, null);
         this.alquilerService = alquilerService;
     }
 
-    public void execute() throws RentexpresException {
-        AlquilerCreateDialog dlg = new AlquilerCreateDialog(frame);
-        dlg.setVisible(true);
-        if (dlg.isConfirmed()) {
-            AlquilerDTO dto = dlg.getAlquiler();
-            try {
-                if (alquilerService.existsByReserva(dto.getIdReserva())) {
-                    SwingUtils.showError(frame, "Esta reserva ya tiene un alquiler asignado.");
-                    return;
-                }
-                alquilerService.create(dto);
-            } catch (RentexpresException ex) {
-                SwingUtils.showError(frame, "Error guardando: " + ex.getMessage());
-            }
+    @Override
+    protected AlquilerCreateDialog createDialog() {
+        return new AlquilerCreateDialog(frame);
+    }
+
+    @Override
+    protected void save(AlquilerDTO dto) throws RentexpresException {
+        if (alquilerService.existsByReserva(dto.getIdReserva())) {
+            throw new RentexpresException("Esta reserva ya tiene un alquiler asignado.");
         }
+        alquilerService.create(dto);
     }
 }

--- a/controller/ShowClienteCreateAction.java
+++ b/controller/ShowClienteCreateAction.java
@@ -7,22 +7,22 @@ import com.pinguela.rentexpres.exception.RentexpresException;
 import com.pinguela.rentexpres.model.ClienteDTO;
 import com.pinguela.rentexpres.service.ClienteService;
 
-public class ShowClienteCreateAction {
+public class ShowClienteCreateAction extends AbstractCreateAction<ClienteDTO, ClienteCreateDialog> {
 
-	private final Frame frame;
-	private final ClienteService clienteService;
+        private final ClienteService clienteService;
 
-	public ShowClienteCreateAction(Frame frame, ClienteService clienteService) {
-		this.frame = frame;
-		this.clienteService = clienteService;
-	}
+        public ShowClienteCreateAction(Frame frame, ClienteService clienteService) {
+                super(frame, null);
+                this.clienteService = clienteService;
+        }
 
-	public void execute() throws RentexpresException {
-		ClienteCreateDialog dlg = new ClienteCreateDialog(frame);
-		dlg.setVisible(true);
-		if (dlg.isConfirmed()) {
-			ClienteDTO dto = dlg.getCliente();
-			clienteService.create(dto);
-		}
-	}
+        @Override
+        protected ClienteCreateDialog createDialog() {
+                return new ClienteCreateDialog(frame);
+        }
+
+        @Override
+        protected void save(ClienteDTO dto) throws RentexpresException {
+                clienteService.create(dto);
+        }
 }

--- a/controller/ShowReservaCreateAction.java
+++ b/controller/ShowReservaCreateAction.java
@@ -1,26 +1,26 @@
 package com.pinguela.rentexpres.desktop.controller;
 
 import java.awt.Frame;
-import com.pinguela.rentexpres.model.ReservaDTO;
-import com.pinguela.rentexpres.service.ReservaService;
 import com.pinguela.rentexpres.desktop.dialog.ReservaCreateDialog;
 import com.pinguela.rentexpres.exception.RentexpresException;
+import com.pinguela.rentexpres.model.ReservaDTO;
+import com.pinguela.rentexpres.service.ReservaService;
 
-public class ShowReservaCreateAction {
-    private final Frame frame;
+public class ShowReservaCreateAction extends AbstractCreateAction<ReservaDTO, ReservaCreateDialog> {
     private final ReservaService reservaService;
 
     public ShowReservaCreateAction(Frame frame, ReservaService reservaService) {
-        this.frame = frame;
+        super(frame, null);
         this.reservaService = reservaService;
     }
 
-    public void execute() throws RentexpresException {
-        ReservaCreateDialog dlg = new ReservaCreateDialog(frame);
-        dlg.setVisible(true);
-        if (dlg.isConfirmed()) {
-            ReservaDTO dto = dlg.getReserva();
-            reservaService.create(dto);
-        }
+    @Override
+    protected ReservaCreateDialog createDialog() {
+        return new ReservaCreateDialog(frame);
+    }
+
+    @Override
+    protected void save(ReservaDTO dto) throws RentexpresException {
+        reservaService.create(dto);
     }
 }

--- a/controller/ShowUsuarioCreateAction.java
+++ b/controller/ShowUsuarioCreateAction.java
@@ -1,35 +1,30 @@
 package com.pinguela.rentexpres.desktop.controller;
 
 import java.awt.Frame;
-import java.awt.event.ActionEvent;
-import javax.swing.AbstractAction;
+
 
 import com.pinguela.rentexpres.desktop.dialog.UsuarioCreateDialog;
 import com.pinguela.rentexpres.desktop.util.ActionCallback;
+import com.pinguela.rentexpres.exception.RentexpresException;
 import com.pinguela.rentexpres.model.UsuarioDTO;
 import com.pinguela.rentexpres.service.UsuarioService;
 
-public class ShowUsuarioCreateAction extends AbstractAction {
+public class ShowUsuarioCreateAction extends AbstractCreateAction<UsuarioDTO, UsuarioCreateDialog> {
     private static final long serialVersionUID = 1L;
-    private final Frame parent;
-    private final ActionCallback afterCreate;
     private final UsuarioService usuarioService;
 
     public ShowUsuarioCreateAction(Frame parent, UsuarioService usuarioService, ActionCallback afterCreate) {
-        super("Nuevo");
-        this.parent = parent;
+        super("Nuevo", parent, afterCreate);
         this.usuarioService = usuarioService;
-        this.afterCreate = afterCreate;
     }
 
     @Override
-    public void actionPerformed(ActionEvent e) {
-        UsuarioCreateDialog dlg = new UsuarioCreateDialog(parent);
-        dlg.setVisible(true);
-        if (dlg.isConfirmed()) {
-            UsuarioDTO dto = dlg.getUsuario();
-            usuarioService.create(dto);
-        }
-        afterCreate.execute();
+    protected UsuarioCreateDialog createDialog() {
+        return new UsuarioCreateDialog(frame);
+    }
+
+    @Override
+    protected void save(UsuarioDTO dto) throws RentexpresException {
+        usuarioService.create(dto);
     }
 }

--- a/controller/ShowVehiculoCreateAction.java
+++ b/controller/ShowVehiculoCreateAction.java
@@ -9,26 +9,26 @@ import com.pinguela.rentexpres.service.CategoriaVehiculoService;
 import com.pinguela.rentexpres.service.EstadoVehiculoService;
 import com.pinguela.rentexpres.service.VehiculoService;
 
-public class ShowVehiculoCreateAction {
-	private final Frame frame;
-	private final VehiculoService vehiculoService;
-	private final CategoriaVehiculoService categoriaService;
-	private final EstadoVehiculoService estadoService;
+public class ShowVehiculoCreateAction extends AbstractCreateAction<VehiculoDTO, VehiculoCreateDialog> {
+        private final VehiculoService vehiculoService;
+        private final CategoriaVehiculoService categoriaService;
+        private final EstadoVehiculoService estadoService;
 
-	public ShowVehiculoCreateAction(Frame frame, VehiculoService vehiculoService,
-			CategoriaVehiculoService categoriaService, EstadoVehiculoService estadoService) {
-		this.frame = frame;
-		this.vehiculoService = vehiculoService;
-		this.categoriaService = categoriaService;
-		this.estadoService = estadoService;
-	}
+        public ShowVehiculoCreateAction(Frame frame, VehiculoService vehiculoService,
+                        CategoriaVehiculoService categoriaService, EstadoVehiculoService estadoService) {
+                super(frame, null);
+                this.vehiculoService = vehiculoService;
+                this.categoriaService = categoriaService;
+                this.estadoService = estadoService;
+        }
 
-	public void execute() throws RentexpresException {
-		VehiculoCreateDialog dlg = new VehiculoCreateDialog(frame, categoriaService.findAll(), estadoService.findAll());
-		dlg.setVisible(true);
-		if (dlg.isConfirmed()) {
-			VehiculoDTO dto = dlg.getVehiculo();
-			vehiculoService.create(dto, null);
-		}
-	}
+        @Override
+        protected VehiculoCreateDialog createDialog() {
+                return new VehiculoCreateDialog(frame, categoriaService.findAll(), estadoService.findAll());
+        }
+
+        @Override
+        protected void save(VehiculoDTO dto) throws RentexpresException {
+                vehiculoService.create(dto, null);
+        }
 }

--- a/dialog/AlquilerCreateDialog.java
+++ b/dialog/AlquilerCreateDialog.java
@@ -28,7 +28,7 @@ import com.toedter.calendar.JDateChooser;
 
 import net.miginfocom.swing.MigLayout;
 
-public class AlquilerCreateDialog extends JDialog {
+public class AlquilerCreateDialog extends JDialog implements ConfirmDialog<AlquilerDTO> {
 	private static final long serialVersionUID = 1L;
 
 	private final JSpinner spnIdReserva = new JSpinner(new SpinnerNumberModel(0, 0, Integer.MAX_VALUE, 1));
@@ -161,8 +161,8 @@ public class AlquilerCreateDialog extends JDialog {
 		return confirmed;
 	}
 
-	public AlquilerDTO getAlquiler() {
-		AlquilerDTO dto = new AlquilerDTO();
+        public AlquilerDTO getAlquiler() {
+                AlquilerDTO dto = new AlquilerDTO();
 		dto.setIdReserva((Integer) spnIdReserva.getValue());
 		dto.setFechaInicioEfectivo(format(dcInicio.getDate()));
 		dto.setFechaFinEfectivo(format(dcFin.getDate()));
@@ -174,6 +174,11 @@ public class AlquilerCreateDialog extends JDialog {
                         dto.setIdUsuario(AppContext.getCurrentUser().getId());
                 }
                 return dto;
+        }
+
+        @Override
+        public AlquilerDTO getValue() {
+                return getAlquiler();
         }
 
 	public void setIdUsuario(Integer id) {

--- a/dialog/ClienteCreateDialog.java
+++ b/dialog/ClienteCreateDialog.java
@@ -31,7 +31,7 @@ import com.toedter.calendar.JDateChooser;
 
 import net.miginfocom.swing.MigLayout;
 
-public class ClienteCreateDialog extends JDialog {
+public class ClienteCreateDialog extends JDialog implements ConfirmDialog<ClienteDTO> {
 	private static final long serialVersionUID = 1L;
 
 	protected final JTextField txtNombre = new JTextField(18);
@@ -207,9 +207,14 @@ public class ClienteCreateDialog extends JDialog {
 		return confirmed;
 	}
 
-	public ClienteDTO getCliente() {
-		return nuevo;
+        public ClienteDTO getCliente() {
+                return nuevo;
 
-	}
+        }
+
+        @Override
+        public ClienteDTO getValue() {
+                return getCliente();
+        }
 
 }

--- a/dialog/ConfirmDialog.java
+++ b/dialog/ConfirmDialog.java
@@ -1,0 +1,12 @@
+package com.pinguela.rentexpres.desktop.dialog;
+
+/**
+ * Simple interface for dialogs that return a value when confirmed.
+ */
+public interface ConfirmDialog<T> {
+    /** Whether the dialog was accepted by the user. */
+    boolean isConfirmed();
+
+    /** Returns the created or edited value. */
+    T getValue();
+}

--- a/dialog/ReservaCreateDialog.java
+++ b/dialog/ReservaCreateDialog.java
@@ -34,7 +34,7 @@ import com.toedter.calendar.JDateChooser;
 /**
  * Diálogo de creación de reservas.
  */
-public class ReservaCreateDialog extends JDialog {
+public class ReservaCreateDialog extends JDialog implements ConfirmDialog<ReservaDTO> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -188,9 +188,14 @@ public class ReservaCreateDialog extends JDialog {
 		return confirmed;
 	}
 
-	public ReservaDTO getReserva() {
-		return createdReserva;
-	}
+        public ReservaDTO getReserva() {
+                return createdReserva;
+        }
+
+        @Override
+        public ReservaDTO getValue() {
+                return getReserva();
+        }
 
 	public boolean validar() {
 		try {

--- a/dialog/UsuarioCreateDialog.java
+++ b/dialog/UsuarioCreateDialog.java
@@ -26,7 +26,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Diálogo para CREAR un nuevo Usuario.
  */
-public class UsuarioCreateDialog extends JDialog {
+public class UsuarioCreateDialog extends JDialog implements ConfirmDialog<UsuarioDTO> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -153,5 +153,10 @@ public class UsuarioCreateDialog extends JDialog {
 
         public UsuarioDTO getUsuario() {
                 return usuario;
+        }
+
+        @Override
+        public UsuarioDTO getValue() {
+                return getUsuario();
         }
 }

--- a/dialog/VehiculoCreateDialog.java
+++ b/dialog/VehiculoCreateDialog.java
@@ -29,7 +29,7 @@ import com.pinguela.rentexpres.model.CategoriaVehiculoDTO;
 import com.pinguela.rentexpres.model.EstadoVehiculoDTO;
 import com.pinguela.rentexpres.model.VehiculoDTO;
 
-public class VehiculoCreateDialog extends JDialog {
+public class VehiculoCreateDialog extends JDialog implements ConfirmDialog<VehiculoDTO> {
 	private static final long serialVersionUID = 1L;
 
 	private JTextField txtMarca;
@@ -243,9 +243,9 @@ public class VehiculoCreateDialog extends JDialog {
 		return confirmed;
 	}
 
-	public VehiculoDTO getVehiculo() {
-		if (!confirmed)
-			return null;
+        public VehiculoDTO getVehiculo() {
+                if (!confirmed)
+                        return null;
 
 		VehiculoDTO dto = new VehiculoDTO();
 		dto.setMarca(txtMarca.getText().trim());
@@ -259,8 +259,13 @@ public class VehiculoCreateDialog extends JDialog {
 		dto.setIdEstadoVehiculo(estado.getId());
 		CategoriaVehiculoDTO categoria = (CategoriaVehiculoDTO) cbCategoria.getSelectedItem();
 		dto.setIdCategoria(categoria.getId());
-		dto.setImagenPath(imagenSeleccionada);
+                dto.setImagenPath(imagenSeleccionada);
 
-		return dto;
-	}
+                return dto;
+        }
+
+        @Override
+        public VehiculoDTO getValue() {
+                return getVehiculo();
+        }
 }


### PR DESCRIPTION
## Summary
- introduce `ConfirmDialog` interface to unify dialog confirmation handling
- add `AbstractCreateAction` for reusable create dialog logic
- implement the interface in all *CreateDialog classes
- refactor create actions to extend the new abstract action class

## Testing
- `javac $(git ls-files '*.java')` *(fails: package com.formdev.flatlaf does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6850620a957483319396b1f33d30cddc