### PR TITLE
Fix AlquilerSearchController compile error

### DIFF
--- a/controller/AlquilerSearchController.java
+++ b/controller/AlquilerSearchController.java
@@ -77,7 +77,7 @@ public class AlquilerSearchController {
 	private void wireListeners() {
 
 		/* a) Filter – cambios */
-		view.getFilterPanel().setOnChange(new AlquilerFilterPanel.OnChangeListener() {
+                view.getFilter().setOnChange(new AlquilerFilterPanel.OnChangeListener() {
 			public void onChange() {
 				if (!initializing && !loading)
 					goFirstPage();
@@ -85,7 +85,7 @@ public class AlquilerSearchController {
 		});
 
 		/* b) Filter – toggle columna seleccionar */
-		view.getFilterPanel().setToggleListener(new AlquilerFilterPanel.ToggleListener() {
+                view.getFilter().setToggleListener(new AlquilerFilterPanel.ToggleListener() {
 			public void onToggle() {
 				view.getTable().toggleSelectColumn();
 			}
@@ -158,7 +158,7 @@ public class AlquilerSearchController {
 	/* ──────────────────────── Combos de Estado ─────────────────────── */
 	private void cargarEstados() {
 		try {
-			JComboBox<EstadoAlquilerDTO> cmb = view.getFilterPanel().getCmbEstado();
+                        JComboBox<EstadoAlquilerDTO> cmb = view.getFilter().getCmbEstado();
 			cmb.removeAllItems();
 
 			EstadoAlquilerDTO todos = new EstadoAlquilerDTO();
@@ -215,7 +215,7 @@ public class AlquilerSearchController {
 	}
 
 	private AlquilerCriteria buildCriteria() {
-		AlquilerFilterPanel f = view.getFilterPanel();
+                AlquilerFilterPanel f = view.getFilter();
 		AlquilerCriteria c = new AlquilerCriteria();
 
 		if (f.getIdAlquiler() != null && f.getIdAlquiler() > 0)


### PR DESCRIPTION
## Summary
- replace deprecated `getFilterPanel()` references
- use `getFilter()` accessor in `AlquilerSearchController`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685195980d208331b2a1431fcebaed4f