### PR TITLE
Fix null SearchVehiculoAction in cell editor

### DIFF
--- a/renderer/VehiculoActionsCellEditor.java
+++ b/renderer/VehiculoActionsCellEditor.java
@@ -26,7 +26,7 @@ public class VehiculoActionsCellEditor extends AbstractActionsCellEditor {
 
         private final Frame frame;
         private final VehiculoService service;
-        private final SearchVehiculoAction searchAction;
+        private SearchVehiculoAction searchAction;
 
 	private VehiculoDTO vehiculoActual;
 
@@ -49,10 +49,10 @@ public class VehiculoActionsCellEditor extends AbstractActionsCellEditor {
 		// Acción Editar
 		btnEdit.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(java.awt.event.ActionEvent e) {
-				if (vehiculoActual != null) {
-					try {
-						List<EstadoVehiculoDTO> estados = searchAction.getEstadoService().findAll();
-						List<CategoriaVehiculoDTO> categorias = searchAction.getCategoriaService().findAll();
+                                if (vehiculoActual != null) {
+                                        try {
+                                                List<EstadoVehiculoDTO> estados = searchAction != null ? searchAction.getEstadoService().findAll() : java.util.Collections.emptyList();
+                                                List<CategoriaVehiculoDTO> categorias = searchAction != null ? searchAction.getCategoriaService().findAll() : java.util.Collections.emptyList();
 
 						VehiculoEditDialog dlg = new VehiculoEditDialog(frame, vehiculoActual, categorias, estados);
 						dlg.setVisible(true);
@@ -107,7 +107,11 @@ public class VehiculoActionsCellEditor extends AbstractActionsCellEditor {
 
 
 
-	public SearchVehiculoAction getSearchAction() {
-		return searchAction;
-	}
+        public SearchVehiculoAction getSearchAction() {
+                return searchAction;
+        }
+
+        public void setSearchAction(SearchVehiculoAction searchAction) {
+                this.searchAction = searchAction;
+        }
 }

--- a/view/VehiculoTablePanel.java
+++ b/view/VehiculoTablePanel.java
@@ -142,7 +142,14 @@ public class VehiculoTablePanel extends JPanel {
 	 * Permite reasignar la SearchVehiculoAction, por ejemplo desde
 	 * VehiculoSearchView una vez que el controlador ya está construido.
 	 */
-	public void setSearchAction(SearchVehiculoAction searchAction) {
-		this.searchAction = searchAction;
-	}
+        public void setSearchAction(SearchVehiculoAction searchAction) {
+                this.searchAction = searchAction;
+                if (tableVehiculo.getColumnCount() > 0) {
+                        int last = tableVehiculo.getColumnModel().getColumnCount() - 1;
+                        javax.swing.table.TableCellEditor editor = tableVehiculo.getColumnModel().getColumn(last).getCellEditor();
+                        if (editor instanceof com.pinguela.rentexpres.desktop.renderer.VehiculoActionsCellEditor) {
+                                ((com.pinguela.rentexpres.desktop.renderer.VehiculoActionsCellEditor) editor).setSearchAction(searchAction);
+                        }
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- avoid NullPointerException in `VehiculoActionsCellEditor` by allowing SearchVehiculoAction to be updated
- propagate updated action into existing cell editor when `VehiculoTablePanel#setSearchAction` is called

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851cde5e2b88331b3f80eb3ac86a5e2