### PR TITLE
Improve rental screen initialization

### DIFF
--- a/RentExpresMainWindow.java
+++ b/RentExpresMainWindow.java
@@ -244,8 +244,9 @@ public class RentExpresMainWindow extends JFrame {
 		rsv.initIfNeeded();
 		contentPanel.add(rsv, "Reservas");
 
-		AlquilerSearchView asv = new AlquilerSearchView(alquilerService, estadoAlqService(), vehiculoService, this);
-		contentPanel.add(asv, "Alquileres");
+                AlquilerSearchView asv = new AlquilerSearchView(alquilerService, estadoAlqService(), vehiculoService, this);
+                asv.initIfNeeded();
+                contentPanel.add(asv, "Alquileres");
 
 		ClienteSearchView csv = new ClienteSearchView(clienteService, provinciaService, localidadService, this);
 		csv.initIfNeeded();

--- a/view/AlquilerSearchView.java
+++ b/view/AlquilerSearchView.java
@@ -13,6 +13,7 @@ public class AlquilerSearchView
         private static final long serialVersionUID = 1L;
 
         private AlquilerSearchController controller;
+        private boolean initialized = false;
 
         public AlquilerSearchView(AlquilerService alquilerSvc, EstadoAlquilerService estadoSvc, VehiculoService vehiculoSvc,
                         Frame owner) throws RentexpresException {
@@ -44,6 +45,13 @@ public class AlquilerSearchView
                                 table.toggleSelectColumn();
                         }
                 });
+        }
+
+        public void initIfNeeded() {
+                if (!initialized) {
+                        controller.goFirstPage();
+                        initialized = true;
+                }
         }
 
         /* ───────── getters se heredan de StandardSearchView ───────── */


### PR DESCRIPTION
## Summary
- allow lazy initialization in `AlquilerSearchView`
- initialize rental view in `RentExpresMainWindow`

## Testing
- `./build_middleware.sh` *(fails: package dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852e13526188331bf18f185f3b7994a