### PR TITLE
Add theme constants and improve filter UI

### DIFF
--- a/dialog/LoginDialog.java
+++ b/dialog/LoginDialog.java
@@ -29,6 +29,7 @@ import com.pinguela.rentexpres.desktop.util.AuthService;
 import com.pinguela.rentexpres.desktop.util.AuthServiceImpl;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
 import com.pinguela.rentexpres.desktop.util.GradientPanel;
+import com.pinguela.rentexpres.desktop.util.AppTheme;
 import com.pinguela.rentexpres.desktop.view.LoginFormPanel;
 import com.pinguela.rentexpres.model.UsuarioDTO;
 
@@ -51,7 +52,8 @@ public class LoginDialog extends JDialog {
 	}
 
 	private void initComponents() {
-                GradientPanel container = new GradientPanel(new Color(240, 247, 255), Color.WHITE);
+                GradientPanel container = new GradientPanel(AppTheme.LOGIN_GRADIENT_START,
+                                AppTheme.LOGIN_GRADIENT_END);
                 container.setLayout(new BorderLayout());
                 container.setBorder(new EmptyBorder(20, 20, 20, 20));
                 getContentPane().add(container);

--- a/util/AppTheme.java
+++ b/util/AppTheme.java
@@ -23,6 +23,10 @@ public final class AppTheme {
     public static final Color NAV_BTN_HOVER_BG = new Color(220, 224, 230);
     public static final Color NAV_BTN_FG = new Color(45, 52, 70);
 
+    /** Colores utilizados en el diálogo de inicio de sesión */
+    public static final Color LOGIN_GRADIENT_START = new Color(240, 247, 255);
+    public static final Color LOGIN_GRADIENT_END = Color.WHITE;
+
     /** Altura por defecto de las filas de las tablas */
     public static final int TABLE_ROW_HEIGHT = 28;
 

--- a/view/ReservaFilterPanel.java
+++ b/view/ReservaFilterPanel.java
@@ -7,6 +7,7 @@ import java.util.function.Consumer;
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import com.pinguela.rentexpres.desktop.util.AppTheme;
 import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
@@ -39,9 +40,9 @@ public class ReservaFilterPanel extends JPanel {
 
 	private final JSlider sldPrecioDia = new JSlider(0, 500, 500);
 
-	private final JTextField txtNombre = new JTextField();
-	private final JTextField txtApellido1 = new JTextField();
-	private final JTextField txtTelefono = new JTextField();
+        private final JTextField txtNombre = new JTextField();
+        private final JTextField txtApellido1 = new JTextField();
+        private final JTextField txtTelefono = new JTextField();
 
 	/* callbacks */
         private com.pinguela.rentexpres.desktop.util.ActionCallback onChange;
@@ -51,14 +52,19 @@ public class ReservaFilterPanel extends JPanel {
 	/** Nueva bandera para suprimir eventos mientras se limpia el panel */
 	private boolean suppressEvents = false;
 
-	public ReservaFilterPanel() {
-		/* ───── apariencia ───── */
-		setBorder(BorderFactory.createTitledBorder("Filtros de Reserva"));
+        public ReservaFilterPanel() {
+                /* ───── apariencia ───── */
+                setBackground(AppTheme.FILTER_BG);
+                setBorder(BorderFactory.createTitledBorder("Filtros de Reserva"));
 		setLayout(new MigLayout("wrap 4,insets 8", "[right]10[150!]20[right]10[150!][]", "[]8[]8[]8[]8[]8[]8[]"));
-		dcFin.setDateFormatString("yyyy-MM-dd");
+                dcFin.setDateFormatString("yyyy-MM-dd");
 
-		sldPrecioDia.setMajorTickSpacing(100);
-		sldPrecioDia.setPaintTicks(true);
+                txtNombre.putClientProperty("JTextField.placeholderText", "Nombre");
+                txtApellido1.putClientProperty("JTextField.placeholderText", "Apellido");
+                txtTelefono.putClientProperty("JTextField.placeholderText", "Teléfono");
+
+                sldPrecioDia.setMajorTickSpacing(100);
+                sldPrecioDia.setPaintTicks(true);
 		sldPrecioDia.setPaintLabels(true);
 
 		int r = 0;

--- a/view/VehiculoFilterPanel.java
+++ b/view/VehiculoFilterPanel.java
@@ -14,6 +14,7 @@ import javax.swing.event.DocumentListener;
 import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import com.pinguela.rentexpres.desktop.util.ActionCallback;
+import com.pinguela.rentexpres.desktop.util.AppTheme;
 
 import com.pinguela.rentexpres.model.CategoriaVehiculoDTO;
 import com.pinguela.rentexpres.model.EstadoVehiculoDTO;
@@ -36,16 +37,23 @@ public class VehiculoFilterPanel extends JPanel {
         private ActionCallback onChange;
         private ActionCallback toggleListener;
 
-	public VehiculoFilterPanel() {
-		setBorder(new TitledBorder("Filtros de Vehículo"));
-		setLayout(new MigLayout("wrap 4", "[right]10[150!]20[right]10[150!][][]", "[]8[]8[]8[]8[]"));
+        public VehiculoFilterPanel() {
+                setBorder(new TitledBorder("Filtros de Vehículo"));
+                setLayout(new MigLayout("wrap 4", "[right]10[150!]20[right]10[150!][][]", "[]8[]8[]8[]8[]"));
+                setBackground(AppTheme.FILTER_BG);
 
 		NumberFormat intFormat = NumberFormat.getIntegerInstance();
 		NumberFormat doubleFormat = NumberFormat.getNumberInstance();
 
-		ftfAnioDesde = new JFormattedTextField(intFormat);
-		ftfAnioHasta = new JFormattedTextField(intFormat);
-		ftfPrecioMax = new JFormattedTextField(doubleFormat);
+                ftfAnioDesde = new JFormattedTextField(intFormat);
+                ftfAnioHasta = new JFormattedTextField(intFormat);
+                ftfPrecioMax = new JFormattedTextField(doubleFormat);
+
+                txtMarca.putClientProperty("JTextField.placeholderText", "Marca");
+                txtModelo.putClientProperty("JTextField.placeholderText", "Modelo");
+                ftfAnioDesde.putClientProperty("JTextField.placeholderText", "Desde");
+                ftfAnioHasta.putClientProperty("JTextField.placeholderText", "Hasta");
+                ftfPrecioMax.putClientProperty("JTextField.placeholderText", "Máximo");
 
 		// Fila 0: Marca | Modelo
 		add(new JLabel("Marca:"), "cell 0 0");


### PR DESCRIPTION
## Summary
- tweak login dialog to use theme colors
- add login gradient colors to `AppTheme`
- improve `ReservaFilterPanel` styling and placeholders
- improve `VehiculoFilterPanel` styling and placeholders

## Testing
- `./build_middleware.sh` *(fails: package org.apache.logging.log4j does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68531e2a7e74833188b127bc7b745627