### PR TITLE
Improve login dialog aesthetics

### DIFF
--- a/dialog/LoginDialog.java
+++ b/dialog/LoginDialog.java
@@ -40,7 +40,8 @@ public class LoginDialog extends JDialog {
 	private final JButton btnIngresar = new JButton("Ingresar");
 	private final JButton btnCancelar = new JButton("Cancelar");
 
-	private UsuarioDTO authenticatedUser = null;
+        private UsuarioDTO authenticatedUser = null;
+        private boolean rememberUser = false;
 	private final AuthService authService = new AuthServiceImpl();
 
 	public LoginDialog(Frame parent) {
@@ -92,15 +93,15 @@ public class LoginDialog extends JDialog {
 		btnIngresar.setPreferredSize(new Dimension(120, 40));
 		btnIngresar.setFont(btnIngresar.getFont().deriveFont(Font.PLAIN, 14f));
 		btnIngresar.setFocusPainted(false);
-		btnIngresar.setBackground(new Color(33, 150, 243));
+                btnIngresar.setBackground(AppTheme.PRIMARY);
                 btnIngresar.setForeground(Color.WHITE);
                 btnIngresar.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 
 		btnCancelar.setPreferredSize(new Dimension(120, 40));
 		btnCancelar.setFont(btnCancelar.getFont().deriveFont(Font.PLAIN, 14f));
 		btnCancelar.setFocusPainted(false);
-		btnCancelar.setBackground(new Color(238, 238, 238));
-		btnCancelar.setForeground(new Color(55, 71, 79));
+                btnCancelar.setBackground(AppTheme.CANCEL);
+                btnCancelar.setForeground(AppTheme.CANCEL_FG);
 		btnCancelar.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
                btnCancelar.addActionListener(new ActionListener() {
                        @Override
@@ -148,11 +149,12 @@ public class LoginDialog extends JDialog {
 		}
 
 		try {
-			UsuarioDTO user = authService.authenticate(username, password);
-			if (user != null) {
-				authenticatedUser = user;
-				dispose();
-			} else {
+                        UsuarioDTO user = authService.authenticate(username, password);
+                        if (user != null) {
+                                authenticatedUser = user;
+                                rememberUser = formPanel.isRememberMe();
+                                dispose();
+                        } else {
 				SwingUtils.showError(this, "Credenciales incorrectas.");
 				formPanel.clear();
 			}
@@ -161,9 +163,14 @@ public class LoginDialog extends JDialog {
 		}
 	}
 
-	public UsuarioDTO showDialog() {
-		formPanel.clear();
-		setVisible(true);
-		return authenticatedUser;
-	}
+        public UsuarioDTO showDialog() {
+                formPanel.clear();
+                rememberUser = false;
+                setVisible(true);
+                return authenticatedUser;
+        }
+
+        public boolean isRememberUser() {
+                return rememberUser;
+        }
 }

--- a/util/AppTheme.java
+++ b/util/AppTheme.java
@@ -24,7 +24,7 @@ public final class AppTheme {
     public static final Color NAV_BTN_FG = new Color(45, 52, 70);
 
     /** Colores utilizados en el diálogo de inicio de sesión */
-    public static final Color LOGIN_GRADIENT_START = new Color(240, 247, 255);
+    public static final Color LOGIN_GRADIENT_START = new Color(225, 242, 254);
     public static final Color LOGIN_GRADIENT_END = Color.WHITE;
 
     /** Color de texto para etiquetas en paneles */
@@ -38,6 +38,10 @@ public final class AppTheme {
 
     /** Color acento para botones primarios. */
     public static final Color PRIMARY = new Color(33, 150, 243);
+
+    /** Color para botones secundarios/cancelar. */
+    public static final Color CANCEL = new Color(238, 238, 238);
+    public static final Color CANCEL_FG = new Color(55, 71, 79);
 
     /** Configura FlatLaf y algunos colores por defecto. */
     public static void setup() {

--- a/view/LoginFormPanel.java
+++ b/view/LoginFormPanel.java
@@ -12,6 +12,7 @@ public class LoginFormPanel extends JPanel {
 
         private final JTextField txtUsername = new JTextField(20);
         private final JPasswordField txtPassword = new JPasswordField(20);
+        private final JCheckBox chkRemember = new JCheckBox("Recordar usuario");
 
 	public LoginFormPanel() {
 		setLayout(new GridBagLayout());
@@ -48,18 +49,29 @@ public class LoginFormPanel extends JPanel {
                 gbc.gridx = 0;
                 gbc.gridy = 3;
                 add(txtPassword, gbc);
+
+                chkRemember.setOpaque(false);
+                chkRemember.setFont(chkRemember.getFont().deriveFont(Font.PLAIN, 13f));
+                gbc.gridx = 0;
+                gbc.gridy = 4;
+                add(chkRemember, gbc);
 	}
 
 	public String getUsername() {
 		return txtUsername.getText().trim();
 	}
 
-	public String getPassword() {
-		return new String(txtPassword.getPassword());
-	}
+        public String getPassword() {
+                return new String(txtPassword.getPassword());
+        }
 
-	public void clear() {
-		txtUsername.setText("");
-		txtPassword.setText("");
-	}
+        public boolean isRememberMe() {
+                return chkRemember.isSelected();
+        }
+
+        public void clear() {
+                txtUsername.setText("");
+                txtPassword.setText("");
+                chkRemember.setSelected(false);
+        }
 }


### PR DESCRIPTION
## Summary
- enhance LoginFormPanel with a "Remember user" checkbox
- allow LoginDialog to return whether the user wants to be remembered
- apply consistent button colours using `AppTheme`
- tweak login gradient colours and expose cancel button colours

## Testing
- `./build_middleware.sh` *(fails: package org.apache.logging.log4j does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6853f78bf9c08331bbe727904c1dcd62