### PR TITLE
Enhance login dialog with remember and show password

### DIFF
--- a/dialog/LoginDialog.java
+++ b/dialog/LoginDialog.java
@@ -140,25 +140,40 @@ public class LoginDialog extends JDialog {
 		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
 	}
 
-	private void onIngresar(ActionEvent e) {
-		String username = formPanel.getUsername();
-		String password = formPanel.getPassword();
+       private void onIngresar(ActionEvent e) {
+               String username = formPanel.getUsername();
+               String password = formPanel.getPassword();
 
-		if (username.trim().isEmpty() || password.trim().isEmpty()) {
-			SwingUtils.showWarning(this, "Debe ingresar usuario y contraseña.");
-			return;
-		}
+               if (username.trim().isEmpty() || password.trim().isEmpty()) {
+                       SwingUtils.showWarning(this, "Debe ingresar usuario y contraseña.");
+                       return;
+               }
 
-				SwingUtils.showError(this, "Credenciales incorrectas.");
-				formPanel.clear();
-			}
-		} catch (Exception ex) {
-			SwingUtils.showError(this, "Error al autenticar: " + ex.getMessage());
-		}
-	}
+               try {
+                       UsuarioDTO user = authService.authenticate(username, password);
+                       if (user == null) {
+                               SwingUtils.showError(this, "Credenciales incorrectas.");
+                               formPanel.clearPassword();
+                               return;
+                       }
+                       authenticatedUser = user;
+                       AppContext.setCurrentUser(user);
+                       rememberUser = formPanel.isRememberSelected();
+                       if (rememberUser) {
+                               AppContext.setRememberedUser(username);
+                       } else {
+                               AppContext.setRememberedUser(null);
+                       }
+                       dispose();
+               } catch (Exception ex) {
+                       SwingUtils.showError(this, "Error al autenticar: " + ex.getMessage());
+               }
+       }
 
-        public UsuarioDTO showDialog() {
-                formPanel.clear();
-        }
-}
+       public UsuarioDTO showDialog() {
+               formPanel.clear();
+               formPanel.setUsername(AppContext.getRememberedUser());
+               setVisible(true);
+               return authenticatedUser;
+       }
 }

--- a/view/LoginFormPanel.java
+++ b/view/LoginFormPanel.java
@@ -12,6 +12,9 @@ public class LoginFormPanel extends JPanel {
 
         private final JTextField txtUsername = new JTextField(20);
         private final JPasswordField txtPassword = new JPasswordField(20);
+        private final JCheckBox chkRemember = new JCheckBox("Recordarme");
+        private final JCheckBox chkShowPass = new JCheckBox("Mostrar contraseña");
+        private final char defaultEcho = txtPassword.getEchoChar();
 
 	public LoginFormPanel() {
 		setLayout(new GridBagLayout());
@@ -53,7 +56,15 @@ public class LoginFormPanel extends JPanel {
                 gbc.gridx = 0;
                 gbc.gridy = 4;
                 add(chkRemember, gbc);
-	}
+
+                chkShowPass.setOpaque(false);
+                chkShowPass.addActionListener(e -> {
+                        txtPassword.setEchoChar(chkShowPass.isSelected() ? (char)0 : defaultEcho);
+                });
+                gbc.gridx = 0;
+                gbc.gridy = 5;
+                add(chkShowPass, gbc);
+        }
 
 	public String getUsername() {
 		return txtUsername.getText().trim();
@@ -61,5 +72,25 @@ public class LoginFormPanel extends JPanel {
 
         public String getPassword() {
                 return new String(txtPassword.getPassword());
+        }
+
+        public boolean isRememberSelected() {
+                return chkRemember.isSelected();
+        }
+
+        public void clear() {
+                txtUsername.setText("");
+                txtPassword.setText("");
+                chkRemember.setSelected(false);
+                chkShowPass.setSelected(false);
+                txtPassword.setEchoChar(defaultEcho);
+        }
+
+        public void clearPassword() {
+                txtPassword.setText("");
+        }
+
+        public void setUsername(String username) {
+                txtUsername.setText(username == null ? "" : username);
         }
 }


### PR DESCRIPTION
## Summary
- add 'Recordarme' and 'Mostrar contraseña' checkboxes in login form
- allow clearing and setting username along with password visibility toggle
- enhance login dialog to persist remembered user and allow showing password

## Testing
- `./build_middleware.sh` *(fails: package dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685402b8c11c8331bb5b02cac457d749