### PR TITLE
Remove filter icons and improve profile editing

### DIFF
--- a/view/AlquilerFilterPanel.java
+++ b/view/AlquilerFilterPanel.java
@@ -74,31 +74,21 @@ public class AlquilerFilterPanel extends JPanel {
                 NumberFormat intFormat = NumberFormat.getIntegerInstance();
                 ftfKmInicial = new JFormattedTextField(intFormat);
                 ftfKmInicial.putClientProperty("JTextField.placeholderText", "Inicial");
-                ftfKmInicial.putClientProperty("JTextField.leadingIcon", AppIcons.ALQUILER);
                 ftfKmFinal = new JFormattedTextField(intFormat);
                 ftfKmFinal.putClientProperty("JTextField.placeholderText", "Final");
-                ftfKmFinal.putClientProperty("JTextField.leadingIcon", AppIcons.ALQUILER);
 
                 NumberFormat doubleFormat = NumberFormat.getNumberInstance();
                 ftfCosteTotal = new JFormattedTextField(doubleFormat);
                 ftfCosteTotal.putClientProperty("JTextField.placeholderText", "Total");
-                ftfCosteTotal.putClientProperty("JTextField.leadingIcon", AppIcons.ALQUILER);
                 ftfPrecioDia = new JFormattedTextField(doubleFormat);
                 ftfPrecioDia.putClientProperty("JTextField.placeholderText", "€/día");
-                ftfPrecioDia.putClientProperty("JTextField.leadingIcon", AppIcons.ALQUILER);
 
                 txtNombre.putClientProperty("JTextField.placeholderText", "Nombre");
-                txtNombre.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                 txtApellido.putClientProperty("JTextField.placeholderText", "Apellido");
-                txtApellido.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                 txtTelefono.putClientProperty("JTextField.placeholderText", "Teléfono");
-                txtTelefono.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                 txtPlaca.putClientProperty("JTextField.placeholderText", "Placa");
-                txtPlaca.putClientProperty("JTextField.leadingIcon", AppIcons.VEHICULO);
                 txtMarca.putClientProperty("JTextField.placeholderText", "Marca");
-                txtMarca.putClientProperty("JTextField.leadingIcon", AppIcons.VEHICULO);
                 txtModelo.putClientProperty("JTextField.placeholderText", "Modelo");
-                txtModelo.putClientProperty("JTextField.leadingIcon", AppIcons.VEHICULO);
 
                 dcInicio.setDateFormatString("yyyy-MM-dd");
                 dcFin.setDateFormatString("yyyy-MM-dd");

--- a/view/ClienteFilterPanel.java
+++ b/view/ClienteFilterPanel.java
@@ -63,17 +63,11 @@ public class ClienteFilterPanel extends JPanel {
                setBackground(AppTheme.FILTER_BG);
 
                txtNombre.putClientProperty("JTextField.placeholderText", "Nombre");
-               txtNombre.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                txtApellido1.putClientProperty("JTextField.placeholderText", "Apellido 1");
-               txtApellido1.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                txtApellido2.putClientProperty("JTextField.placeholderText", "Apellido 2");
-               txtApellido2.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                txtEmail.putClientProperty("JTextField.placeholderText", "Email");
-               txtEmail.putClientProperty("JTextField.leadingIcon", AppIcons.VER);
                txtTelefono.putClientProperty("JTextField.placeholderText", "Teléfono");
-               txtTelefono.putClientProperty("JTextField.leadingIcon", AppIcons.VER);
                txtCalle.putClientProperty("JTextField.placeholderText", "Calle");
-               txtCalle.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                txtNumero.putClientProperty("JTextField.placeholderText", "Nº");
 
                initLayout();

--- a/view/ReservaFilterPanel.java
+++ b/view/ReservaFilterPanel.java
@@ -69,11 +69,8 @@ public class ReservaFilterPanel extends JPanel {
                 dcFin.setDateFormatString("yyyy-MM-dd");
 
                 txtNombre.putClientProperty("JTextField.placeholderText", "Nombre");
-                txtNombre.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                 txtApellido1.putClientProperty("JTextField.placeholderText", "Apellido");
-                txtApellido1.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                 txtTelefono.putClientProperty("JTextField.placeholderText", "Teléfono");
-                txtTelefono.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
 
                 sldPrecioDia.setMajorTickSpacing(100);
                 sldPrecioDia.setPaintTicks(true);

--- a/view/UsuarioFilterPanel.java
+++ b/view/UsuarioFilterPanel.java
@@ -54,15 +54,10 @@ public class UsuarioFilterPanel extends JPanel {
                 setBackground(AppTheme.FILTER_BG);
 
                 txtNombre.putClientProperty("JTextField.placeholderText", "Nombre");
-                txtNombre.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                 txtApellido1.putClientProperty("JTextField.placeholderText", "Apellido 1");
-                txtApellido1.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                 txtApellido2.putClientProperty("JTextField.placeholderText", "Apellido 2");
-                txtApellido2.putClientProperty("JTextField.leadingIcon", AppIcons.CLIENTE);
                 txtEmail.putClientProperty("JTextField.placeholderText", "Email");
-                txtEmail.putClientProperty("JTextField.leadingIcon", AppIcons.VER);
                 txtUsuario.putClientProperty("JTextField.placeholderText", "Usuario");
-                txtUsuario.putClientProperty("JTextField.leadingIcon", AppIcons.USUARIO);
 
 		// Fila 1: ID y Nombre
                 add(lbl("ID:"), "right");

--- a/view/VehiculoFilterPanel.java
+++ b/view/VehiculoFilterPanel.java
@@ -59,15 +59,10 @@ public class VehiculoFilterPanel extends JPanel {
                 ftfPrecioMax = new JFormattedTextField(doubleFormat);
 
                 txtMarca.putClientProperty("JTextField.placeholderText", "Marca");
-                txtMarca.putClientProperty("JTextField.leadingIcon", AppIcons.VEHICULO);
                 txtModelo.putClientProperty("JTextField.placeholderText", "Modelo");
-                txtModelo.putClientProperty("JTextField.leadingIcon", AppIcons.VEHICULO);
                 ftfAnioDesde.putClientProperty("JTextField.placeholderText", "Desde");
                 ftfAnioHasta.putClientProperty("JTextField.placeholderText", "Hasta");
                 ftfPrecioMax.putClientProperty("JTextField.placeholderText", "Máximo");
-                ftfAnioDesde.putClientProperty("JTextField.leadingIcon", AppIcons.VEHICULO);
-                ftfAnioHasta.putClientProperty("JTextField.leadingIcon", AppIcons.VEHICULO);
-                ftfPrecioMax.putClientProperty("JTextField.leadingIcon", AppIcons.VEHICULO);
 
 		// Fila 0: Marca | Modelo
                 add(lbl("Marca:"), "cell 0 0");


### PR DESCRIPTION
## Summary
- remove leading icons from all filter panel text fields
- extend user profile dialog with extra fields and an edit option

## Testing
- `./build_middleware.sh` *(fails: package org.apache.commons.lang3.builder does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68541516e42c8331a6c8ceb9af24d39f