### PR TITLE
Fix button text color in theme

### DIFF
--- a/util/AppTheme.java
+++ b/util/AppTheme.java
@@ -56,7 +56,9 @@ public final class AppTheme {
 
         UIManager.put("Panel.background", DIALOG_BG);
         UIManager.put("Button.background", PRIMARY);
-        UIManager.put("Button.foreground", Color.WHITE);
+        // Establecer un color de texto oscuro por defecto para botones.
+        // Los botones primarios se colorean individualmente en blanco donde corresponde.
+        UIManager.put("Button.foreground", NAV_BTN_FG);
     }
 }
 


### PR DESCRIPTION
## Summary
- set default button text color to dark grey so text isn't hidden

## Testing
- `./build_middleware.sh` *(fails: package org.apache.logging.log4j does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685416c60ec08331bfad862212b7d740