### PR TITLE
Improve filter layout spacing

### DIFF
--- a/view/AlquilerFilterPanel.java
+++ b/view/AlquilerFilterPanel.java
@@ -15,6 +15,8 @@ import com.pinguela.rentexpres.desktop.util.AppTheme;
 import com.pinguela.rentexpres.desktop.util.AppIcons;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.border.TitledBorder;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
@@ -67,8 +69,8 @@ public class AlquilerFilterPanel extends JPanel {
         }
 
         public AlquilerFilterPanel() {
-                setBorder(new TitledBorder("Filtros de Alquiler"));
-                setLayout(new MigLayout("wrap 4", "[right]10[150!]20[right]10[150!]", "[]8[]8[]8[]8[]"));
+                setBorder(new CompoundBorder(new TitledBorder("Filtros de Alquiler"), new EmptyBorder(10,10,10,10)));
+                setLayout(new MigLayout("wrap 4,fillx", "[right]10[grow,fill]20[right]10[grow,fill]", "[]8[]8[]8[]8[]"));
                 setBackground(AppTheme.FILTER_BG);
 
                 NumberFormat intFormat = NumberFormat.getIntegerInstance();

--- a/view/ClienteFilterPanel.java
+++ b/view/ClienteFilterPanel.java
@@ -1,6 +1,8 @@
 package com.pinguela.rentexpres.desktop.view;
 
 import net.miginfocom.swing.MigLayout;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
 
 import java.awt.Color;
 
@@ -58,8 +60,8 @@ public class ClienteFilterPanel extends JPanel {
        }
 
        public ClienteFilterPanel() {
-               super(new MigLayout("wrap 4", "[right]10[150!]20[right]10[150!]", "[]8[]8[]8[]8[]"));
-               setBorder(javax.swing.BorderFactory.createTitledBorder("Filtros de Cliente"));
+               super(new MigLayout("wrap 4,fillx", "[right]10[grow,fill]20[right]10[grow,fill]", "[]8[]8[]8[]8[]"));
+               setBorder(new CompoundBorder(new TitledBorder("Filtros de Cliente"), new EmptyBorder(10,10,10,10)));
                setBackground(AppTheme.FILTER_BG);
 
                txtNombre.putClientProperty("JTextField.placeholderText", "Nombre");

--- a/view/UsuarioFilterPanel.java
+++ b/view/UsuarioFilterPanel.java
@@ -15,6 +15,8 @@ import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.border.TitledBorder;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
 import com.pinguela.rentexpres.desktop.util.AppTheme;
 import com.pinguela.rentexpres.desktop.util.AppIcons;
 
@@ -48,9 +50,9 @@ public class UsuarioFilterPanel extends JPanel {
                 return l;
         }
 
-	public UsuarioFilterPanel() {
-                setBorder(new TitledBorder("Filtros Usuarios"));
-                setLayout(new MigLayout("wrap 4", "[right][grow,fill][right][grow,fill]", "[]10[]10[]"));
+        public UsuarioFilterPanel() {
+                setBorder(new CompoundBorder(new TitledBorder("Filtros Usuarios"), new EmptyBorder(10,10,10,10)));
+                setLayout(new MigLayout("wrap 4,fillx", "[right][grow,fill][right][grow,fill]", "[]10[]10[]"));
                 setBackground(AppTheme.FILTER_BG);
 
                 txtNombre.putClientProperty("JTextField.placeholderText", "Nombre");


### PR DESCRIPTION
## Summary
- add padding with CompoundBorder to filter panels
- make filter panel layouts fill horizontally for better spacing

## Testing
- `./build_middleware.sh` *(fails: package org.apache.logging.log4j does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6854255129f4833189b220eb57f28419