### PR TITLE
Improve layout of login and profile dialogs

### DIFF
--- a/dialog/LoginDialog.java
+++ b/dialog/LoginDialog.java
@@ -15,7 +15,6 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 
 import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -60,27 +59,22 @@ public class LoginDialog extends JDialog {
                 container.setBorder(new EmptyBorder(20, 20, 20, 20));
                 getContentPane().add(container);
 
-                JPanel topPanel = new JPanel();
+                JPanel topPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 20, 10));
                 topPanel.setOpaque(false);
-                topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.Y_AXIS));
 
-		JLabel lblTitle = new JLabel("¡Bienvenido a RentExpres!", SwingConstants.CENTER);
-		lblTitle.setFont(lblTitle.getFont().deriveFont(Font.BOLD, 22f));
-		lblTitle.setForeground(new Color(45, 45, 45));
-		lblTitle.setAlignmentX(Component.CENTER_ALIGNMENT);
-		topPanel.add(lblTitle);
+                JLabel lblTitle = new JLabel("¡Bienvenido a RentExpres!");
+                lblTitle.setFont(lblTitle.getFont().deriveFont(Font.BOLD, 22f));
+                lblTitle.setForeground(new Color(45, 45, 45));
 
-		topPanel.add(Box.createRigidArea(new Dimension(0, 15)));
+                if (AppIcons.ALQUILER != null) {
+                        ImageIcon vehicleIcon = AppIcons.ALQUILER;
+                        Image scaled = vehicleIcon.getImage().getScaledInstance(80, 80, Image.SCALE_SMOOTH);
+                        JLabel lblIcon = new JLabel(new ImageIcon(scaled));
+                        topPanel.add(lblIcon);
+                }
 
-		if (AppIcons.ALQUILER != null) {
-			ImageIcon vehicleIcon = AppIcons.ALQUILER;
-			Image scaled = vehicleIcon.getImage().getScaledInstance(100, 100, Image.SCALE_SMOOTH);
-			JLabel lblIcon = new JLabel(new ImageIcon(scaled));
-			lblIcon.setAlignmentX(Component.CENTER_ALIGNMENT);
-			topPanel.add(lblIcon);
-		}
-
-		container.add(topPanel, BorderLayout.NORTH);
+                topPanel.add(lblTitle);
+                container.add(topPanel, BorderLayout.NORTH);
 
                 JPanel centerPanel = new JPanel(new BorderLayout());
                 centerPanel.setOpaque(false);

--- a/view/LoginFormPanel.java
+++ b/view/LoginFormPanel.java
@@ -17,44 +17,49 @@ public class LoginFormPanel extends JPanel {
         private final char defaultEcho = txtPassword.getEchoChar();
 
 	public LoginFormPanel() {
-		setLayout(new GridBagLayout());
-		setBorder(new EmptyBorder(20, 20, 20, 20));
-		setOpaque(false);
+                setLayout(new GridBagLayout());
+                setBorder(new EmptyBorder(20, 20, 20, 20));
+                setOpaque(false);
 
-		GridBagConstraints gbc = new GridBagConstraints();
-		gbc.anchor = GridBagConstraints.CENTER;
-		gbc.insets = new Insets(8, 8, 8, 8);
-		gbc.fill = GridBagConstraints.HORIZONTAL;
+                GridBagConstraints gbc = new GridBagConstraints();
+                gbc.insets = new Insets(8, 8, 8, 8);
+                gbc.fill = GridBagConstraints.HORIZONTAL;
 
                 JLabel lblUser = new JLabel("Usuario");
                 lblUser.setFont(lblUser.getFont().deriveFont(Font.PLAIN, 14f));
                 gbc.gridx = 0;
                 gbc.gridy = 0;
+                gbc.anchor = GridBagConstraints.EAST;
                 add(lblUser, gbc);
 
                 txtUsername.setFont(txtUsername.getFont().deriveFont(14f));
                 txtUsername.putClientProperty("JTextField.placeholderText", "Nombre de usuario");
                 txtUsername.putClientProperty("JTextField.leadingIcon", AppIcons.USUARIO);
-                gbc.gridx = 0;
-                gbc.gridy = 1;
+                gbc.gridx = 1;
+                gbc.gridy = 0;
+                gbc.anchor = GridBagConstraints.WEST;
                 add(txtUsername, gbc);
 
                 JLabel lblPass = new JLabel("Contraseña");
                 lblPass.setFont(lblPass.getFont().deriveFont(Font.PLAIN, 14f));
                 gbc.gridx = 0;
-                gbc.gridy = 2;
+                gbc.gridy = 1;
+                gbc.anchor = GridBagConstraints.EAST;
                 add(lblPass, gbc);
 
                 txtPassword.setFont(txtPassword.getFont().deriveFont(14f));
                 txtPassword.putClientProperty("JTextField.placeholderText", "Contraseña");
                 txtPassword.putClientProperty("JTextField.leadingIcon", AppIcons.VIEW);
-                gbc.gridx = 0;
-                gbc.gridy = 3;
+                gbc.gridx = 1;
+                gbc.gridy = 1;
+                gbc.anchor = GridBagConstraints.WEST;
                 add(txtPassword, gbc);
 
                 chkRemember.setOpaque(false);
                 gbc.gridx = 0;
-                gbc.gridy = 4;
+                gbc.gridy = 2;
+                gbc.gridwidth = 2;
+                gbc.anchor = GridBagConstraints.WEST;
                 add(chkRemember, gbc);
 
                 chkShowPass.setOpaque(false);
@@ -62,7 +67,9 @@ public class LoginFormPanel extends JPanel {
                         txtPassword.setEchoChar(chkShowPass.isSelected() ? (char)0 : defaultEcho);
                 });
                 gbc.gridx = 0;
-                gbc.gridy = 5;
+                gbc.gridy = 3;
+                gbc.gridwidth = 2;
+                gbc.anchor = GridBagConstraints.WEST;
                 add(chkShowPass, gbc);
         }
 

--- a/view/ProfileView.java
+++ b/view/ProfileView.java
@@ -12,7 +12,6 @@ import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -28,6 +27,8 @@ import com.pinguela.rentexpres.desktop.dialog.UsuarioEditDialog;
 import com.pinguela.rentexpres.service.UsuarioService;
 import com.pinguela.rentexpres.service.impl.UsuarioServiceImpl;
 import com.pinguela.rentexpres.model.UsuarioDTO;
+
+import net.miginfocom.swing.MigLayout;
 
 /**
  * Diálogo de Perfil de Usuario, con diseño estilizado. El botón "Cerrar Sesión"
@@ -80,35 +81,40 @@ public class ProfileView extends JDialog {
 		container.add(topPanel, BorderLayout.NORTH);
 
 		// Panel central: información de usuario en líneas
-		JPanel infoPanel = new JPanel();
-		infoPanel.setBackground(Color.WHITE);
-		infoPanel.setLayout(new BoxLayout(infoPanel, BoxLayout.Y_AXIS));
-		infoPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
+                JPanel infoPanel = new JPanel();
+                infoPanel.setBackground(Color.WHITE);
+                infoPanel.setLayout(new MigLayout("wrap 2", "[right]10[grow,fill]", "[]10[]10[]10[]10[]10[]"));
+                infoPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
 
-		lblNombre.setFont(lblNombre.getFont().deriveFont(Font.PLAIN, 16f));
-		lblNombre.setForeground(new Color(30, 30, 30));
-		lblNombre.setBorder(new EmptyBorder(10, 0, 5, 0));
-		infoPanel.add(lblNombre);
+                lblNombre.setFont(lblNombre.getFont().deriveFont(Font.PLAIN, 16f));
+                lblNombre.setForeground(new Color(30, 30, 30));
+                lblNombre.setBorder(new EmptyBorder(0, 0, 0, 0));
+                infoPanel.add(new JLabel("Nombre:"));
+                infoPanel.add(lblNombre);
 
                 lblEmail.setFont(lblEmail.getFont().deriveFont(Font.PLAIN, 16f));
                 lblEmail.setForeground(new Color(30, 30, 30));
-                lblEmail.setBorder(new EmptyBorder(5, 0, 5, 0));
+                lblEmail.setBorder(new EmptyBorder(0, 0, 0, 0));
+                infoPanel.add(new JLabel("Email:"));
                 infoPanel.add(lblEmail);
 
                 lblUsuario.setFont(lblUsuario.getFont().deriveFont(Font.PLAIN, 16f));
                 lblUsuario.setForeground(new Color(30, 30, 30));
-                lblUsuario.setBorder(new EmptyBorder(5, 0, 5, 0));
+                lblUsuario.setBorder(new EmptyBorder(0, 0, 0, 0));
+                infoPanel.add(new JLabel("Usuario:"));
                 infoPanel.add(lblUsuario);
 
                 lblTelefono.setFont(lblTelefono.getFont().deriveFont(Font.PLAIN, 16f));
                 lblTelefono.setForeground(new Color(30, 30, 30));
-                lblTelefono.setBorder(new EmptyBorder(5, 0, 5, 0));
+                lblTelefono.setBorder(new EmptyBorder(0, 0, 0, 0));
+                infoPanel.add(new JLabel("Teléfono:"));
                 infoPanel.add(lblTelefono);
 
-		lblTipo.setFont(lblTipo.getFont().deriveFont(Font.PLAIN, 16f));
-		lblTipo.setForeground(new Color(30, 30, 30));
-		lblTipo.setBorder(new EmptyBorder(5, 0, 10, 0));
-		infoPanel.add(lblTipo);
+                lblTipo.setFont(lblTipo.getFont().deriveFont(Font.PLAIN, 16f));
+                lblTipo.setForeground(new Color(30, 30, 30));
+                lblTipo.setBorder(new EmptyBorder(0, 0, 10, 0));
+                infoPanel.add(new JLabel("Tipo:"));
+                infoPanel.add(lblTipo);
 
 		// Separator para estética
 		JSeparator separator = new JSeparator();
@@ -158,19 +164,19 @@ public class ProfileView extends JDialog {
 	}
 
 	private void loadUserData() {
-		UsuarioDTO u = AppContext.getCurrentUser();
+                UsuarioDTO u = AppContext.getCurrentUser();
                 if (u != null) {
-                        lblNombre.setText("Nombre: " + u.getNombre() + " " + u.getApellido1() + " " + u.getApellido2());
-                        lblEmail.setText("Email: " + u.getEmail());
-                        lblUsuario.setText("Usuario: " + u.getNombreUsuario());
-                        lblTelefono.setText("Teléfono: " + u.getTelefono());
-                        lblTipo.setText("Tipo: " + u.getIdTipoUsuario());
+                        lblNombre.setText(u.getNombre() + " " + u.getApellido1() + " " + u.getApellido2());
+                        lblEmail.setText(u.getEmail());
+                        lblUsuario.setText(u.getNombreUsuario());
+                        lblTelefono.setText(u.getTelefono());
+                        lblTipo.setText(String.valueOf(u.getIdTipoUsuario()));
                 } else {
-                        lblNombre.setText("No hay usuario autenticado.");
-                        lblEmail.setText("");
-                        lblUsuario.setText("");
-                        lblTelefono.setText("");
-                        lblTipo.setText("");
+                        lblNombre.setText("-");
+                        lblEmail.setText("-");
+                        lblUsuario.setText("-");
+                        lblTelefono.setText("-");
+                        lblTipo.setText("-");
                 }
 	}
 


### PR DESCRIPTION
## Summary
- update login dialog layout to show icon and title side by side
- restructure login form with two-column GridBagLayout
- redesign profile view with MigLayout for better space usage

## Testing
- `./build_middleware.sh` *(fails: package dependencies missing)*
- `javac -classpath lib/middleware/RentExpres.jar:lib/calendar/jcalendar-1.4.jar -d /tmp/classes dialog/LoginDialog.java view/LoginFormPanel.java view/ProfileView.java` *(fails: package dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68542deeb1148331af2cbc3ff323e51d