### PR TITLE
Improve details dialog layout

### DIFF
--- a/dialog/AlquilerDetailDialog.java
+++ b/dialog/AlquilerDetailDialog.java
@@ -30,8 +30,10 @@ public class AlquilerDetailDialog extends JDialog {
 		super(owner, "Detalle del Alquiler", true);
 		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
 
-		JPanel content = new JPanel(
-				new MigLayout("wrap 2", "[right][grow,fill]", "[]10[]10[]10[]10[]10[]10[]10[]10[]10[]10[]20[]"));
+                JPanel content = new JPanel(
+                                new MigLayout("wrap 4",
+                                                "[right]10[grow,fill]20[right]10[grow,fill]",
+                                                "[]10[]10[]10[]10[]10[]10[]10[]10[]10[]10[]20[]"));
 		content.setBorder(new EmptyBorder(15, 20, 15, 20));
 		ClienteDTO cliente;
 		EstadoAlquilerDTO estado;

--- a/dialog/ReservaDetailDialog.java
+++ b/dialog/ReservaDetailDialog.java
@@ -28,7 +28,9 @@ public class ReservaDetailDialog extends JDialog {
 
 	private void initComponents(ReservaDTO r) {
 		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-		setLayout(new MigLayout("wrap 2", "[right][grow,fill]", "[]10[]10[]10[]10[]20[]"));
+                setLayout(new MigLayout("wrap 4",
+                                "[right]10[grow,fill]20[right]10[grow,fill]",
+                                "[]10[]10[]10[]10[]20[]"));
 
 		ClienteServiceImpl clienteService = new ClienteServiceImpl();
 		EstadoReservaServiceImpl estadoService = new EstadoReservaServiceImpl();


### PR DESCRIPTION
## Summary
- switch details dialogs to 4-column MigLayout for better horizontal space usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68543566357483318ddaaa57abc28781