### PR TITLE
fix: restore search and nav layouts

### DIFF
--- a/RentExpresMainWindow.java
+++ b/RentExpresMainWindow.java
@@ -166,26 +166,35 @@ public class RentExpresMainWindow extends JFrame {
         Color btnFg = AppTheme.NAV_BTN_FG;
 
                 navPanel.setBackground(navBg);
-                navPanel.setPreferredSize(new Dimension(260, getHeight()));
-                navPanel.setLayout(new GridLayout(0, 2, 10, 10));
+                navPanel.setPreferredSize(new Dimension(200, getHeight()));
+                navPanel.setLayout(new BoxLayout(navPanel, BoxLayout.Y_AXIS));
 
+                navPanel.add(Box.createVerticalStrut(20));
                 navPanel.add(createNavButton("Inicio", AppIcons.INICIO, btnBg, btnHoverBg, btnFg));
+                navPanel.add(Box.createVerticalStrut(10));
                 navPanel.add(createNavButton("Reservas", AppIcons.RESERVA, btnBg, btnHoverBg, btnFg));
+                navPanel.add(Box.createVerticalStrut(10));
                 navPanel.add(createNavButton("Alquileres", AppIcons.ALQUILER, btnBg, btnHoverBg, btnFg));
+                navPanel.add(Box.createVerticalStrut(10));
                 navPanel.add(createNavButton("Calendario", AppIcons.RESERVA, btnBg, btnHoverBg, btnFg));
+                navPanel.add(Box.createVerticalStrut(10));
                 navPanel.add(createNavButton("Clientes", AppIcons.CLIENTE, btnBg, btnHoverBg, btnFg));
+                navPanel.add(Box.createVerticalStrut(10));
 
                 if (AppContext.getCurrentUser().getIdTipoUsuario() == 1) {
                         navPanel.add(createNavButton("Usuarios", AppIcons.USUARIO, btnBg, btnHoverBg, btnFg));
+                        navPanel.add(Box.createVerticalStrut(10));
                         navPanel.add(createNavButton("Vehículos", AppIcons.VEHICULO, btnBg, btnHoverBg, btnFg));
                 }
+                navPanel.add(Box.createVerticalGlue());
         }
 
 	private JButton createNavButton(String text, ImageIcon icon, Color bg, Color hoverBg, Color fg) {
-		JButton btn = new JButton(text, icon);
-                btn.setHorizontalAlignment(SwingConstants.CENTER);
-                btn.setMaximumSize(new Dimension(120, 50));
-                btn.setPreferredSize(new Dimension(120, 50));
+                JButton btn = new JButton(text, icon);
+                btn.setHorizontalAlignment(SwingConstants.LEFT);
+                btn.setAlignmentX(Component.CENTER_ALIGNMENT);
+                btn.setMaximumSize(new Dimension(180, 50));
+                btn.setPreferredSize(new Dimension(180, 50));
 		btn.setFocusPainted(false);
 		btn.setBackground(bg);
 		btn.setForeground(fg);

--- a/view/StandardSearchView.java
+++ b/view/StandardSearchView.java
@@ -1,14 +1,13 @@
 package com.pinguela.rentexpres.desktop.view;
 
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import com.pinguela.rentexpres.desktop.util.PaginationPanel;
 
 /**
  * Generic view providing standard layout for search screens:
- * a sidebar on the left with filter panel and actions,
+ * filter panel on top, actions right below,
  * the table in the center and pagination panel at the bottom.
  */
 public class StandardSearchView<F extends JPanel, A extends AbstractSearchActionsView, T extends JPanel>
@@ -26,15 +25,14 @@ public class StandardSearchView<F extends JPanel, A extends AbstractSearchAction
         this.table = table;
         this.pager = new PaginationPanel();
 
-        JPanel sidebar = new JPanel(new BorderLayout(0, 8));
-        sidebar.add(filter, BorderLayout.CENTER);
-        sidebar.add(actions, BorderLayout.SOUTH);
-        sidebar.setPreferredSize(new Dimension(300, 0));
+        JPanel north = new JPanel(new BorderLayout(0, 4));
+        north.add(filter, BorderLayout.NORTH);
+        north.add(actions, BorderLayout.SOUTH);
 
         JScrollPane scroll = new JScrollPane(table);
 
         setLayout(new BorderLayout(8, 8));
-        add(sidebar, BorderLayout.WEST);
+        add(north, BorderLayout.NORTH);
         add(scroll, BorderLayout.CENTER);
         add(pager, BorderLayout.SOUTH);
     }


### PR DESCRIPTION
## Summary
- revert sidebar search layout to vertical filter layout
- revert navigation panel to vertical layout with left-aligned buttons

## Testing
- `bash build_middleware.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854476a55ec833187506fb942ae1341