### PR TITLE
Fix MigLayout constraint in AlquilerCreateDialog

### DIFF
--- a/dialog/AlquilerCreateDialog.java
+++ b/dialog/AlquilerCreateDialog.java
@@ -52,7 +52,7 @@ public class AlquilerCreateDialog extends JDialog implements ConfirmDialog<Alqui
 	}
 
 	private void initComponents() {
-                setLayout(new MigLayout("wrap 4,insets 15", "[right]10[120:150:grow]20[right]10[120:150:grow]", "[]10[]10[]10[]10[]"));
+                setLayout(new MigLayout("wrap 4,insets 15", "[right]10[120:150,grow]20[right]10[120:150,grow]", "[]10[]10[]10[]10[]"));
                 dcInicio.setDateFormatString("yyyy-MM-dd");
                 dcFin.setDateFormatString("yyyy-MM-dd");
 


### PR DESCRIPTION
## Summary
- fix column constraint syntax in AlquilerCreateDialog

## Testing
- `./build_middleware.sh`
- `javac -cp lib/middleware/RentExpres.jar:lib/calendar/jcalendar-1.4.jar -d /tmp/build $(find . -name '*.java' | tr '\n' ' ')` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854497cb7508331bdabedf87d2c3f6b