### PR TITLE
Fix search view layout

### DIFF
--- a/view/StandardSearchView.java
+++ b/view/StandardSearchView.java
@@ -26,8 +26,8 @@ public class StandardSearchView<F extends JPanel, A extends AbstractSearchAction
         this.pager = new PaginationPanel();
 
         JPanel north = new JPanel(new BorderLayout(0, 4));
-        north.add(filter, BorderLayout.NORTH);
-        north.add(actions, BorderLayout.SOUTH);
+        north.add(actions, BorderLayout.NORTH);
+        north.add(filter, BorderLayout.SOUTH);
 
         JScrollPane scroll = new JScrollPane(table);
 


### PR DESCRIPTION
## Summary
- adjust `StandardSearchView` so the action buttons sit above the filters

## Testing
- `./build_middleware.sh` *(fails: missing dependencies)*
- `javac -cp lib/middleware/RentExpres.jar -d out @sources.txt` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68544d2957948331875c1806a60aefc6