### PR TITLE
Fix logout double login

### DIFF
--- a/RentExpresMainWindow.java
+++ b/RentExpresMainWindow.java
@@ -139,9 +139,8 @@ public class RentExpresMainWindow extends JFrame {
                        @Override
                        public void actionPerformed(ActionEvent e) {
                                new LogoutAction(RentExpresMainWindow.this).actionPerformed(null);
-                               UsuarioDTO newUser = showLoginDialog();
-                               if (newUser != null) {
-                                       AppContext.setCurrentUser(newUser);
+                               UsuarioDTO current = AppContext.getCurrentUser();
+                               if (current != null) {
                                        topBar.removeAll();
                                        initTopBar();
                                        revalidate();


### PR DESCRIPTION
## Summary
- avoid opening the login dialog twice when logging out

## Testing
- `./build_middleware.sh`
- `javac` *(fails: cannot find symbol FlatLightLaf, MigLayout, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68544e80def48331bf68370124e56e48