### PR TITLE
Refactor view logic into controllers

### DIFF
--- a/controller/AuthController.java
+++ b/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.pinguela.rentexpres.desktop.controller;
+
+import com.pinguela.rentexpres.desktop.util.AppContext;
+import com.pinguela.rentexpres.desktop.util.AuthService;
+import com.pinguela.rentexpres.desktop.util.AuthServiceImpl;
+import com.pinguela.rentexpres.model.UsuarioDTO;
+
+/** Simple controller for login operations. */
+public class AuthController {
+    private final AuthService authService = new AuthServiceImpl();
+
+    /**
+     * Attempt to authenticate the user with the given credentials.
+     * If successful, updates the {@link AppContext} accordingly.
+     */
+    public UsuarioDTO login(String username, String password, boolean remember) throws Exception {
+        UsuarioDTO user = authService.authenticate(username, password);
+        if (user != null) {
+            AppContext.setCurrentUser(user);
+            if (remember) {
+                AppContext.setRememberedUser(username);
+            } else {
+                AppContext.setRememberedUser(null);
+            }
+        }
+        return user;
+    }
+}

--- a/controller/ClienteRowController.java
+++ b/controller/ClienteRowController.java
@@ -1,0 +1,60 @@
+package com.pinguela.rentexpres.desktop.controller;
+
+import java.awt.Component;
+import java.awt.Frame;
+
+import javax.swing.JOptionPane;
+
+import com.pinguela.rentexpres.desktop.dialog.ClienteDetailDialog;
+import com.pinguela.rentexpres.desktop.dialog.ClienteEditDialog;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
+import com.pinguela.rentexpres.desktop.util.SwingUtils;
+import com.pinguela.rentexpres.exception.RentexpresException;
+import com.pinguela.rentexpres.model.ClienteDTO;
+import com.pinguela.rentexpres.service.ClienteService;
+
+/** Controller for actions on a single cliente row. */
+public class ClienteRowController {
+    private final Frame frame;
+    private final ClienteService service;
+    private final ActionCallback reload;
+
+    public ClienteRowController(Frame frame, ClienteService service, ActionCallback reload) {
+        this.frame = frame;
+        this.service = service;
+        this.reload = reload;
+    }
+
+    public void showDetail(ClienteDTO dto) {
+        if (dto != null) {
+            new ClienteDetailDialog(frame, dto).setVisible(true);
+        }
+    }
+
+    public void edit(ClienteDTO dto) {
+        if (dto == null) return;
+        ClienteEditDialog dlg = new ClienteEditDialog(frame, dto);
+        dlg.setVisible(true);
+        if (dlg.isConfirmed()) {
+            try {
+                service.update(dlg.getCliente());
+                if (reload != null) reload.execute();
+            } catch (RentexpresException ex) {
+                SwingUtils.showError(frame, ex.getMessage());
+            }
+        }
+    }
+
+    public void delete(ClienteDTO dto) {
+        if (dto == null) return;
+        if (SwingUtils.showConfirm(frame,
+                "¿Eliminar cliente " + dto.getId() + "?", "Confirmar borrado") == JOptionPane.YES_OPTION) {
+            try {
+                service.delete(dto.getId());
+                if (reload != null) reload.execute();
+            } catch (RentexpresException ex) {
+                SwingUtils.showError(frame, ex.getMessage());
+            }
+        }
+    }
+}

--- a/controller/ProfileController.java
+++ b/controller/ProfileController.java
@@ -1,0 +1,37 @@
+package com.pinguela.rentexpres.desktop.controller;
+
+import java.util.List;
+
+import com.pinguela.rentexpres.desktop.util.AppContext;
+import com.pinguela.rentexpres.model.UsuarioDTO;
+import com.pinguela.rentexpres.service.UsuarioService;
+
+/** Controller for user profile operations. */
+public class ProfileController {
+    private final UsuarioService usuarioService;
+
+    public ProfileController(UsuarioService usuarioService) {
+        this.usuarioService = usuarioService;
+    }
+
+    /** Returns the current user refreshed from persistence. */
+    public UsuarioDTO getCurrentUser() throws Exception {
+        UsuarioDTO current = AppContext.getCurrentUser();
+        if (current == null) return null;
+        UsuarioDTO refreshed = usuarioService.findById(current.getId());
+        AppContext.setCurrentUser(refreshed);
+        return refreshed;
+    }
+
+    public List<String> getUsuarioImages(int userId) throws Exception {
+        return usuarioService.getUsuarioImages(userId);
+    }
+
+    /** Updates the user and refreshes the current user context. */
+    public UsuarioDTO updateUsuario(UsuarioDTO updated) throws Exception {
+        usuarioService.update(updated);
+        UsuarioDTO refreshed = usuarioService.findById(updated.getId());
+        AppContext.setCurrentUser(refreshed);
+        return refreshed;
+    }
+}

--- a/controller/UsuarioRowController.java
+++ b/controller/UsuarioRowController.java
@@ -1,0 +1,60 @@
+package com.pinguela.rentexpres.desktop.controller;
+
+import java.awt.Frame;
+
+import javax.swing.JOptionPane;
+
+import com.pinguela.rentexpres.desktop.dialog.UsuarioDetailDialog;
+import com.pinguela.rentexpres.desktop.dialog.UsuarioEditDialog;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
+import com.pinguela.rentexpres.desktop.util.SwingUtils;
+import com.pinguela.rentexpres.model.UsuarioDTO;
+import com.pinguela.rentexpres.service.UsuarioService;
+
+/** Controller to handle actions on a single usuario row. */
+public class UsuarioRowController {
+    private final Frame frame;
+    private final UsuarioService usuarioService;
+    private final ActionCallback reload;
+
+    public UsuarioRowController(Frame frame, UsuarioService usuarioService, ActionCallback reload) {
+        this.frame = frame;
+        this.usuarioService = usuarioService;
+        this.reload = reload;
+    }
+
+    public void showDetail(UsuarioDTO dto) {
+        if (dto != null) {
+            new UsuarioDetailDialog(frame, dto.getId()).setVisible(true);
+        }
+    }
+
+    public void edit(UsuarioDTO dto) {
+        if (dto == null) return;
+        UsuarioEditDialog dlg = new UsuarioEditDialog(frame, dto.getId());
+        dlg.setVisible(true);
+        if (dlg.isConfirmed()) {
+            try {
+                usuarioService.update(dlg.getUsuario());
+                if (reload != null) reload.execute();
+            } catch (Exception ex) {
+                SwingUtils.showError(frame, ex.getMessage());
+            }
+        }
+    }
+
+    public void delete(UsuarioDTO dto) {
+        if (dto == null) return;
+        int resp = JOptionPane.showConfirmDialog(frame,
+                "¿Seguro que deseas eliminar al usuario " + dto.getNombre() + "?",
+                "Eliminar Usuario", JOptionPane.YES_NO_OPTION);
+        if (resp == JOptionPane.YES_OPTION) {
+            try {
+                usuarioService.delete(dto, dto.getId());
+                if (reload != null) reload.execute();
+            } catch (Exception ex) {
+                SwingUtils.showError(frame, ex.getMessage());
+            }
+        }
+    }
+}

--- a/dialog/LoginDialog.java
+++ b/dialog/LoginDialog.java
@@ -22,13 +22,12 @@ import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 
 import com.pinguela.rentexpres.desktop.util.AppIcons;
-import com.pinguela.rentexpres.desktop.util.AuthService;
-import com.pinguela.rentexpres.desktop.util.AuthServiceImpl;
-import com.pinguela.rentexpres.desktop.util.AppContext;
+import com.pinguela.rentexpres.desktop.controller.AuthController;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
 import com.pinguela.rentexpres.desktop.util.GradientPanel;
 import com.pinguela.rentexpres.desktop.util.AppTheme;
 import com.pinguela.rentexpres.desktop.view.LoginFormPanel;
+import com.pinguela.rentexpres.desktop.util.AppContext;
 import com.pinguela.rentexpres.model.UsuarioDTO;
 import net.miginfocom.swing.MigLayout;
 
@@ -41,7 +40,7 @@ public class LoginDialog extends JDialog {
 
         private UsuarioDTO authenticatedUser = null;
         private boolean rememberUser = false;
-	private final AuthService authService = new AuthServiceImpl();
+        private final AuthController authController = new AuthController();
 
 	public LoginDialog(Frame parent) {
 		super(parent, "Bienvenido a RentExpres", true);
@@ -135,20 +134,14 @@ public class LoginDialog extends JDialog {
                }
 
                try {
-                       UsuarioDTO user = authService.authenticate(username, password);
+                       rememberUser = formPanel.isRememberSelected();
+                       UsuarioDTO user = authController.login(username, password, rememberUser);
                        if (user == null) {
                                SwingUtils.showError(this, "Credenciales incorrectas.");
                                formPanel.clearPassword();
                                return;
                        }
                        authenticatedUser = user;
-                       AppContext.setCurrentUser(user);
-                       rememberUser = formPanel.isRememberSelected();
-                       if (rememberUser) {
-                               AppContext.setRememberedUser(username);
-                       } else {
-                               AppContext.setRememberedUser(null);
-                       }
                        dispose();
                } catch (Exception ex) {
                        SwingUtils.showError(this, "Error al autenticar: " + ex.getMessage());

--- a/renderer/ClienteActionsCellEditor.java
+++ b/renderer/ClienteActionsCellEditor.java
@@ -5,25 +5,21 @@ import java.awt.Frame;
 import java.util.EventObject;
 import java.util.function.Supplier;
 
-import javax.swing.JOptionPane;
 import javax.swing.JTable;
 
 import com.pinguela.rentexpres.desktop.renderer.AbstractActionsCellEditor;
 
-import com.pinguela.rentexpres.desktop.dialog.ClienteDetailDialog;
-import com.pinguela.rentexpres.desktop.dialog.ClienteEditDialog;
 import com.pinguela.rentexpres.desktop.model.ClienteSearchTableModel;
 import com.pinguela.rentexpres.desktop.util.ActionCallback;
-import com.pinguela.rentexpres.desktop.util.SwingUtils;
-import com.pinguela.rentexpres.exception.RentexpresException;
 import com.pinguela.rentexpres.model.ClienteDTO;
 import com.pinguela.rentexpres.service.ClienteService;
+import com.pinguela.rentexpres.desktop.controller.ClienteRowController;
 
 public class ClienteActionsCellEditor extends AbstractActionsCellEditor {
 	private static final long serialVersionUID = 1L;
 
         private final Frame frame;
-        private final ClienteService service;
+        private final ClienteRowController controller;
         private final ActionCallback reload;
         private final Supplier<ClienteDTO> rowSupplier;
         private ClienteDTO clienteActual;
@@ -32,53 +28,27 @@ public class ClienteActionsCellEditor extends AbstractActionsCellEditor {
                         Supplier<ClienteDTO> rowSupplier) {
                 super();
                 this.frame = owner;
-                this.service = service;
                 this.reload = reload;
                 this.rowSupplier = rowSupplier;
+                this.controller = new ClienteRowController(owner, service, reload);
 
-		btnView.addActionListener(new java.awt.event.ActionListener() {
-			public void actionPerformed(java.awt.event.ActionEvent e) {
-                                if (clienteActual != null) {
-                                        new ClienteDetailDialog(frame, clienteActual).setVisible(true);
-                                }
+                btnView.addActionListener(new java.awt.event.ActionListener() {
+                        public void actionPerformed(java.awt.event.ActionEvent e) {
+                                controller.showDetail(clienteActual);
                                 fireEditingStopped();
                         }
                 });
 
-		btnEdit.addActionListener(new java.awt.event.ActionListener() {
-			public void actionPerformed(java.awt.event.ActionEvent e) {
-                                if (clienteActual != null) {
-                                        ClienteEditDialog dlg = new ClienteEditDialog(frame, clienteActual);
-                                        dlg.setVisible(true);
-                                        if (dlg.isConfirmed()) {
-                                                try {
-                                                        service.update(dlg.getCliente());
-                                                        if (reload != null) {
-                                                                reload.execute();
-                                                        }
-                                                } catch (RentexpresException ex) {
-                                                        SwingUtils.showError(frame, ex.getMessage());
-                                                }
-                                        }
-                                }
+                btnEdit.addActionListener(new java.awt.event.ActionListener() {
+                        public void actionPerformed(java.awt.event.ActionEvent e) {
+                                controller.edit(clienteActual);
                                 fireEditingStopped();
                         }
                 });
 
-		btnDel.addActionListener(new java.awt.event.ActionListener() {
-			public void actionPerformed(java.awt.event.ActionEvent e) {
-                                if (clienteActual != null
-                                                && SwingUtils.showConfirm(frame, "¿Eliminar cliente " + clienteActual.getId() + "?",
-                                                                "Confirmar borrado") == JOptionPane.YES_OPTION) {
-                                        try {
-                                                service.delete(clienteActual.getId());
-                                                if (reload != null) {
-                                                        reload.execute();
-                                                }
-                                        } catch (RentexpresException ex) {
-                                                SwingUtils.showError(frame, ex.getMessage());
-                                        }
-                                }
+                btnDel.addActionListener(new java.awt.event.ActionListener() {
+                        public void actionPerformed(java.awt.event.ActionEvent e) {
+                                controller.delete(clienteActual);
                                 fireEditingStopped();
                         }
                 });

--- a/renderer/UsuarioActionsCellEditor.java
+++ b/renderer/UsuarioActionsCellEditor.java
@@ -6,15 +6,12 @@ import java.util.function.Supplier;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import javax.swing.JOptionPane;
 import javax.swing.JTable;
 
 import com.pinguela.rentexpres.desktop.renderer.AbstractActionsCellEditor;
 
 import com.pinguela.rentexpres.desktop.util.ActionCallback;
-import com.pinguela.rentexpres.desktop.util.SwingUtils;
-import com.pinguela.rentexpres.desktop.dialog.UsuarioDetailDialog;
-import com.pinguela.rentexpres.desktop.dialog.UsuarioEditDialog;
+import com.pinguela.rentexpres.desktop.controller.UsuarioRowController;
 
 import com.pinguela.rentexpres.model.UsuarioDTO;
 import com.pinguela.rentexpres.service.UsuarioService;
@@ -25,7 +22,7 @@ public class UsuarioActionsCellEditor extends AbstractActionsCellEditor {
         private static final long serialVersionUID = 1L;
 
         private final Frame owner;
-        private final UsuarioService usuarioService;
+        private final UsuarioRowController controller;
         private final ActionCallback reload;
         private final Supplier<UsuarioDTO> rowSupplier;
         private UsuarioDTO usuarioActual;
@@ -34,16 +31,14 @@ public class UsuarioActionsCellEditor extends AbstractActionsCellEditor {
                         Supplier<UsuarioDTO> rowSupplier) {
                 super();
                 this.owner = owner;
-                this.usuarioService = usuarioService;
                 this.reload = reload;
                 this.rowSupplier = rowSupplier;
+                this.controller = new UsuarioRowController(owner, usuarioService, reload);
 
                btnView.addActionListener(new ActionListener() {
                        @Override
                        public void actionPerformed(ActionEvent e) {
-                               if (usuarioActual != null) {
-                                       new UsuarioDetailDialog(owner, usuarioActual.getId()).setVisible(true);
-                               }
+                               controller.showDetail(usuarioActual);
                                fireEditingStopped();
                        }
                });
@@ -51,20 +46,7 @@ public class UsuarioActionsCellEditor extends AbstractActionsCellEditor {
                btnEdit.addActionListener(new ActionListener() {
                        @Override
                        public void actionPerformed(ActionEvent e) {
-                               if (usuarioActual != null) {
-                                       UsuarioEditDialog dlg = new UsuarioEditDialog(owner, usuarioActual.getId());
-                                       dlg.setVisible(true);
-                                       if (dlg.isConfirmed()) {
-                                               try {
-                                                       usuarioService.update(dlg.getUsuario());
-                                                       if (reload != null) {
-                                                               reload.execute();
-                                                       }
-                                               } catch (Exception ex) {
-                                                       SwingUtils.showError(owner, ex.getMessage());
-                                               }
-                                       }
-                               }
+                               controller.edit(usuarioActual);
                                fireEditingStopped();
                        }
                });
@@ -72,21 +54,7 @@ public class UsuarioActionsCellEditor extends AbstractActionsCellEditor {
                btnDel.addActionListener(new ActionListener() {
                        @Override
                        public void actionPerformed(ActionEvent e) {
-                               if (usuarioActual != null) {
-                                       int resp = JOptionPane.showConfirmDialog(owner,
-                                                       "¿Seguro que deseas eliminar al usuario " + usuarioActual.getNombre() + "?", "Eliminar Usuario",
-                                                       JOptionPane.YES_NO_OPTION);
-                                       if (resp == JOptionPane.YES_OPTION) {
-                                               try {
-                                                       usuarioService.delete(usuarioActual, usuarioActual.getId());
-                                                       if (reload != null) {
-                                                               reload.execute();
-                                                       }
-                                               } catch (Exception ex) {
-                                                       SwingUtils.showError(owner, ex.getMessage());
-                                               }
-                                       }
-                               }
+                               controller.delete(usuarioActual);
                                fireEditingStopped();
                        }
                });
@@ -118,11 +86,7 @@ public class UsuarioActionsCellEditor extends AbstractActionsCellEditor {
                 return reload;
         }
 
-	public UsuarioService getUsuarioService() {
-		return usuarioService;
-	}
-
-	public Frame getOwner() {
-		return owner;
-	}
+        public Frame getOwner() {
+                return owner;
+        }
 }


### PR DESCRIPTION
## Summary
- move authentication logic to new `AuthController`
- extract profile actions into `ProfileController`
- add row controllers for user and client tables
- update `LoginDialog` and `ProfileView` to use controllers
- refactor `UsuarioActionsCellEditor` and `ClienteActionsCellEditor`

## Testing
- `./build_middleware.sh`

------
https://chatgpt.com/codex/tasks/task_e_685478bcc2448331bf49c8c5ec3aeb2c