### PR TITLE
Fix unresolved onBuscar error

### DIFF
--- a/view/UsuarioSearchActionsView.java
+++ b/view/UsuarioSearchActionsView.java
@@ -1,11 +1,22 @@
 package com.pinguela.rentexpres.desktop.view;
 
 /** Barra de acciones reutilizable para Usuarios. */
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
+
 public class UsuarioSearchActionsView extends AbstractSearchActionsView {
     private static final long serialVersionUID = 1L;
 
     public UsuarioSearchActionsView() {
         super();
+    }
+
+    /**
+     * Delegates to the parent implementation. This method exists explicitly
+     * to avoid build issues when older compiled classes are present.
+     */
+    @Override
+    public void onBuscar(ActionCallback r) {
+        super.onBuscar(r);
     }
 }
 


### PR DESCRIPTION
## Summary
- add explicit `onBuscar` override in `UsuarioSearchActionsView`

## Testing
- `javac -cp lib/middleware/RentExpres.jar:lib/calendar/calendar.jar -d build view/AbstractSearchActionsView.java view/UsuarioSearchActionsView.java` *(fails: package com.pinguela.rentexpres.desktop.util does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6854800626448331848b52685c48b55f