### PR TITLE
Remove search button and use imports

### DIFF
--- a/RentExpresMainWindow.java
+++ b/RentExpresMainWindow.java
@@ -31,6 +31,7 @@ import com.pinguela.rentexpres.desktop.dialog.LoginDialog;
 import com.pinguela.rentexpres.desktop.util.AppContext;
 import com.pinguela.rentexpres.desktop.util.AppIcons;
 import com.pinguela.rentexpres.desktop.util.AppTheme;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
 import com.pinguela.rentexpres.desktop.view.AlquilerSearchView;
 import com.pinguela.rentexpres.desktop.view.ClienteSearchView;
 import com.pinguela.rentexpres.desktop.view.ProfileView;
@@ -285,7 +286,7 @@ public class RentExpresMainWindow extends JFrame {
 
        public static void main(String[] args) {
                System.setProperty("log4j.configurationFile", "config/log4j2.properties");
-               com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+               com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new ActionCallback() {
                        @Override
                        public void execute() {
                                try {

--- a/controller/AlquilerSearchController.java
+++ b/controller/AlquilerSearchController.java
@@ -11,6 +11,8 @@ import com.pinguela.rentexpres.desktop.dialog.AlquilerCreateDialog;
 import com.pinguela.rentexpres.desktop.model.AlquilerSearchTableModel;
 import com.pinguela.rentexpres.desktop.util.CatalogCache;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
+import com.pinguela.rentexpres.desktop.util.PaginationPanel;
 import com.pinguela.rentexpres.desktop.view.AlquilerFilterPanel;
 import com.pinguela.rentexpres.desktop.view.AlquilerSearchActionsView;
 import com.pinguela.rentexpres.desktop.view.AlquilerSearchView;
@@ -98,19 +100,19 @@ public class AlquilerSearchController {
 		view.getPager().onLast(new PaginationPanelListener(PaginationPanelListener.LAST));
 
                 /* d) Botones de acciones */
-                view.getActions().onNuevo(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                view.getActions().onNuevo(new ActionCallback() {
                         @Override
                         public void execute() {
                                 abrirNuevo();
                         }
                 });
-                view.getActions().onBuscar(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                view.getActions().onBuscar(new ActionCallback() {
                         @Override
                         public void execute() {
                                 goFirstPage();
                         }
                 });
-                view.getActions().onLimpiar(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                view.getActions().onLimpiar(new ActionCallback() {
                         @Override
                         public void execute() {
                                 view.getFilter().clear();
@@ -118,7 +120,7 @@ public class AlquilerSearchController {
                                 goFirstPage();
                         }
                 });
-                view.getActions().onBorrarSeleccionados(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                view.getActions().onBorrarSeleccionados(new ActionCallback() {
                         @Override
                         public void execute() {
                                 borrarSeleccionados();
@@ -129,8 +131,8 @@ public class AlquilerSearchController {
 	/*
 	 * ────────────────── Auxiliar para el paginador (sin lambdas) ─────────────────
 	 */
-	private class PaginationPanelListener
-			implements com.pinguela.rentexpres.desktop.util.PaginationPanel.OnPagerListener {
+        private class PaginationPanelListener
+                        implements PaginationPanel.OnPagerListener {
 		static final int FIRST = 9999;
 		static final int LAST = -9999;
 		private final int delta;

--- a/controller/ReservaController.java
+++ b/controller/ReservaController.java
@@ -11,6 +11,7 @@ import com.pinguela.rentexpres.desktop.dialog.ReservaDetailDialog;
 import com.pinguela.rentexpres.desktop.dialog.ReservaEditDialog;
 import com.pinguela.rentexpres.desktop.model.ReservaSearchTableModel;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
 import com.pinguela.rentexpres.exception.RentexpresException;
 import com.pinguela.rentexpres.model.ReservaDTO;
 import com.pinguela.rentexpres.service.ReservaService;
@@ -104,14 +105,14 @@ public class ReservaController {
                 try {
                     final List<ReservaDTO> reservas = service.findAll();
 
-                    com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                    com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new ActionCallback() {
                         @Override
                         public void execute() {
                             table.setModel(new ReservaSearchTableModel(reservas, null));
                         }
                     });
                 } catch (RentexpresException ex) {
-                    com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                    com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new ActionCallback() {
                         @Override
                         public void execute() {
                             SwingUtils.showError(frame, ERROR_CARGANDO + ex.getMessage());
@@ -129,14 +130,14 @@ public class ReservaController {
                 try {
                     service.update(reserva);
 
-                    com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                    com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new ActionCallback() {
                         @Override
                         public void execute() {
                             loadDataAsync();
                         }
                     });
                 } catch (RentexpresException ex) {
-                    com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                    com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new ActionCallback() {
                         @Override
                         public void execute() {
                             SwingUtils.showError(frame, ERROR_ACTUALIZANDO + ex.getMessage());

--- a/controller/UsuarioSearchController.java
+++ b/controller/UsuarioSearchController.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import com.pinguela.rentexpres.desktop.model.UsuarioSearchTableModel;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
+import com.pinguela.rentexpres.desktop.util.PaginationPanel;
 import com.pinguela.rentexpres.desktop.view.UsuarioFilterPanel;
 import com.pinguela.rentexpres.desktop.view.UsuarioSearchActionsView;
 import com.pinguela.rentexpres.desktop.view.UsuarioSearchView;
@@ -39,10 +41,10 @@ public class UsuarioSearchController {
 
     private void wireActions() {
         UsuarioSearchActionsView actions = view.getActions();
-        actions.onNuevo(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+        actions.onNuevo(new ActionCallback() {
             @Override
             public void execute() {
-                new ShowUsuarioCreateAction(frame, service, new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                new ShowUsuarioCreateAction(frame, service, new ActionCallback() {
                     @Override
                     public void execute() {
                         goFirstPage();
@@ -50,19 +52,19 @@ public class UsuarioSearchController {
                 }).actionPerformed(null);
             }
         });
-        actions.onBuscar(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+        actions.onBuscar(new ActionCallback() {
             @Override
             public void execute() {
                 goFirstPage();
             }
         });
-        actions.onLimpiar(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+        actions.onLimpiar(new ActionCallback() {
             @Override
             public void execute() {
                 onLimpiar();
             }
         });
-        actions.onBorrarSeleccionados(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+        actions.onBorrarSeleccionados(new ActionCallback() {
             @Override
             public void execute() {
                 onDeleteSelected();
@@ -71,7 +73,7 @@ public class UsuarioSearchController {
     }
 
     private void wirePager() {
-        view.getPager().onFirst(new com.pinguela.rentexpres.desktop.util.PaginationPanel.OnPagerListener() {
+        view.getPager().onFirst(new PaginationPanel.OnPagerListener() {
             @Override
             public void onAction() {
                 if (!loading) {
@@ -79,7 +81,7 @@ public class UsuarioSearchController {
                 }
             }
         });
-        view.getPager().onPrev(new com.pinguela.rentexpres.desktop.util.PaginationPanel.OnPagerListener() {
+        view.getPager().onPrev(new PaginationPanel.OnPagerListener() {
             @Override
             public void onAction() {
                 if (!loading && currentPage > 1) {
@@ -88,7 +90,7 @@ public class UsuarioSearchController {
                 }
             }
         });
-        view.getPager().onNext(new com.pinguela.rentexpres.desktop.util.PaginationPanel.OnPagerListener() {
+        view.getPager().onNext(new PaginationPanel.OnPagerListener() {
             @Override
             public void onAction() {
                 if (!loading && currentPage < totalPages) {
@@ -97,7 +99,7 @@ public class UsuarioSearchController {
                 }
             }
         });
-        view.getPager().onLast(new com.pinguela.rentexpres.desktop.util.PaginationPanel.OnPagerListener() {
+        view.getPager().onLast(new PaginationPanel.OnPagerListener() {
             @Override
             public void onAction() {
                 if (!loading && currentPage < totalPages) {

--- a/view/AlquilerSearchView.java
+++ b/view/AlquilerSearchView.java
@@ -7,6 +7,7 @@ import com.pinguela.rentexpres.exception.RentexpresException;
 import com.pinguela.rentexpres.service.AlquilerService;
 import com.pinguela.rentexpres.service.EstadoAlquilerService;
 import com.pinguela.rentexpres.service.VehiculoService;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
 
 public class AlquilerSearchView
                 extends StandardSearchView<AlquilerFilterPanel, AlquilerSearchActionsView, AlquilerTablePanel> {
@@ -32,7 +33,7 @@ public class AlquilerSearchView
                         }
                 });
 
-                actions.onLimpiar(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                actions.onLimpiar(new ActionCallback() {
                         @Override
                         public void execute() {
                                 filter.clear();

--- a/view/ReservaFilterPanel.java
+++ b/view/ReservaFilterPanel.java
@@ -9,6 +9,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import com.pinguela.rentexpres.desktop.util.AppTheme;
 import com.pinguela.rentexpres.desktop.util.AppIcons;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
 import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
@@ -48,8 +49,8 @@ public class ReservaFilterPanel extends JPanel {
         private final JTextField txtTelefono = new JTextField();
 
 	/* callbacks */
-        private com.pinguela.rentexpres.desktop.util.ActionCallback onChange;
-        private com.pinguela.rentexpres.desktop.util.ActionCallback toggleListener;
+        private ActionCallback onChange;
+        private ActionCallback toggleListener;
         private Consumer<String> onMarcaChange;
 
 	/** Nueva bandera para suprimir eventos mientras se limpia el panel */
@@ -120,7 +121,7 @@ public class ReservaFilterPanel extends JPanel {
 		// Séptima línea: Teléfono y botón Seleccionar
                 add(lbl("Teléfono:"), "cell 0 " + r);
                 add(txtTelefono, "cell 1 " + r);
-                JButton btnSel = SwingUtils.button("Seleccionar", new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                JButton btnSel = SwingUtils.button("Seleccionar", new ActionCallback() {
                         @Override
                         public void execute() {
                                 fireToggleSelect();
@@ -132,7 +133,7 @@ public class ReservaFilterPanel extends JPanel {
 
 		/* ───── listeners genéricos ───── */
 		// Cada vez que un JTextField cambie, invocamos fire()
-                SwingUtils.addDocumentListener(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+                SwingUtils.addDocumentListener(new ActionCallback() {
                         @Override
                         public void execute() {
                                 fire();
@@ -258,11 +259,11 @@ public class ReservaFilterPanel extends JPanel {
 	}
 
 	/* ───── control externo (el controlador conecta aquí) ───── */
-        public void setOnChange(com.pinguela.rentexpres.desktop.util.ActionCallback r) {
+        public void setOnChange(ActionCallback r) {
                 this.onChange = r;
        }
 
-        public void setToggleListener(com.pinguela.rentexpres.desktop.util.ActionCallback r) {
+        public void setToggleListener(ActionCallback r) {
                 this.toggleListener = r;
        }
 

--- a/view/UsuarioSearchActionsView.java
+++ b/view/UsuarioSearchActionsView.java
@@ -1,10 +1,18 @@
 package com.pinguela.rentexpres.desktop.view;
 
 /** Barra de acciones reutilizable para Usuarios. */
-public class UsuarioSearchActionsView extends AbstractSearchActionsView {
-	private static final long serialVersionUID = 1L;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
 
-	public UsuarioSearchActionsView() {
-		super();
-	}
+public class UsuarioSearchActionsView extends AbstractSearchActionsView {
+        private static final long serialVersionUID = 1L;
+
+        public UsuarioSearchActionsView() {
+                super();
+                remove(btnBuscar);
+        }
+
+        @Override
+        public void onBuscar(ActionCallback r) {
+                // Intentionally empty: this view does not have a search button
+        }
 }

--- a/view/VehiculoSearchView.java
+++ b/view/VehiculoSearchView.java
@@ -7,6 +7,7 @@ import com.pinguela.rentexpres.exception.RentexpresException;
 import com.pinguela.rentexpres.service.CategoriaVehiculoService;
 import com.pinguela.rentexpres.service.EstadoVehiculoService;
 import com.pinguela.rentexpres.service.VehiculoService;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
 
 /**
  * Vista de búsqueda de Vehículos.
@@ -44,7 +45,7 @@ public class VehiculoSearchView
 
                 table.setSearchAction(controller.getSearchAction());
 
-               actions.onLimpiar(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+               actions.onLimpiar(new ActionCallback() {
                        @Override
                        public void execute() {
                                filter.clear();
@@ -53,28 +54,28 @@ public class VehiculoSearchView
                        }
                });
 
-               actions.onBorrarSeleccionados(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+               actions.onBorrarSeleccionados(new ActionCallback() {
                        @Override
                        public void execute() {
                                controller.onEliminarSeleccionados();
                        }
                });
 
-               actions.onNuevo(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+               actions.onNuevo(new ActionCallback() {
                        @Override
                        public void execute() {
                                controller.onNuevoVehiculo();
                        }
                });
 
-               filter.setOnChange(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+               filter.setOnChange(new ActionCallback() {
                        @Override
                        public void execute() {
                                controller.goFirstPage();
                        }
                });
 
-               filter.setToggleListener(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+               filter.setToggleListener(new ActionCallback() {
                        @Override
                        public void execute() {
                                table.toggleSelectColumn();

--- a/view/VehiculoTablePanel.java
+++ b/view/VehiculoTablePanel.java
@@ -15,6 +15,7 @@ import com.pinguela.rentexpres.desktop.renderer.VehiculoTableCellRenderer;
 import com.pinguela.rentexpres.desktop.util.SelectionEditor;
 import com.pinguela.rentexpres.desktop.util.SelectionRenderer;
 import com.pinguela.rentexpres.desktop.util.AppTheme;
+import com.pinguela.rentexpres.desktop.util.ActionCallback;
 import com.pinguela.rentexpres.model.VehiculoDTO;
 import com.pinguela.rentexpres.service.VehiculoService;
 
@@ -86,7 +87,7 @@ public class VehiculoTablePanel extends JPanel {
 	 * método para forzar el ancho de la columna “Acciones”.
 	 */
 	private void ajustarColumnasAcciones() {
-               com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new com.pinguela.rentexpres.desktop.util.ActionCallback() {
+               com.pinguela.rentexpres.desktop.util.SwingUtils.invokeLater(new ActionCallback() {
                        @Override
                        public void execute() {
                                if (tableVehiculo.getColumnCount() == 0)


### PR DESCRIPTION
## Summary
- remove the search button from `UsuarioSearchActionsView`
- import `ActionCallback` and `PaginationPanel` rather than using fully qualified names
- adjust controllers and views to use the new imports

## Testing
- `./build_middleware.sh`
- `javac -cp "lib/calendar/jcalendar-1.4.jar:lib/middleware/RentExpres.jar" @sources.txt` *(fails: package org.apache.commons.lang3.builder does not exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6854840727248331bf9a76234b4263cf