### PR TITLE
Fix AlquilerCreateDialog layout parsing

### DIFF
--- a/dialog/AlquilerCreateDialog.java
+++ b/dialog/AlquilerCreateDialog.java
@@ -52,7 +52,11 @@ public class AlquilerCreateDialog extends JDialog implements ConfirmDialog<Alqui
 	}
 
 	private void initComponents() {
-                setLayout(new MigLayout("wrap 4,insets 15", "[right]10[120:150,grow]20[right]10[120:150,grow]", "[]10[]10[]10[]10[]"));
+               // Simplified column constraints to avoid parsing issues in some environments
+               setLayout(new MigLayout(
+                               "wrap 4,insets 15",
+                               "[right]10[grow,fill]20[right]10[grow,fill]",
+                               "[]10[]10[]10[]10[]"));
                 dcInicio.setDateFormatString("yyyy-MM-dd");
                 dcFin.setDateFormatString("yyyy-MM-dd");
 


### PR DESCRIPTION
## Summary
- simplify MigLayout column constraints in `AlquilerCreateDialog`

## Testing
- `./build_middleware.sh` *(fails: cannot run certain commands due to environment limitations)*
- `javac -d build -cp lib/calendar/jcalendar-1.4.jar:lib/middleware/RentExpres.jar:lib/miglayout.jar dialog/AlquilerCreateDialog.java` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854895e355883318a1a4ee02556d2f4