### PR TITLE
Fix user type display and add brand/model selection

### DIFF
--- a/controller/SearchVehiculoAction.java
+++ b/controller/SearchVehiculoAction.java
@@ -41,7 +41,8 @@ public class SearchVehiculoAction {
 	}
 
         public void showCreate(ActionCallback onReload) throws RentexpresException {
-		VehiculoCreateDialog dlg = new VehiculoCreateDialog(frame, categoriaService.findAll(), estadoService.findAll());
+                VehiculoCreateDialog dlg = new VehiculoCreateDialog(frame, categoriaService.findAll(),
+                                estadoService.findAll(), vehiculoService);
 		dlg.setVisible(true);
 		if (!dlg.isConfirmed()) {
 			return;
@@ -69,8 +70,8 @@ public class SearchVehiculoAction {
 		if (dto == null) {
 			return;
 		}
-		VehiculoEditDialog dlg = new VehiculoEditDialog(frame, dto, categoriaService.findAll(),
-				estadoService.findAll());
+                VehiculoEditDialog dlg = new VehiculoEditDialog(frame, dto, categoriaService.findAll(),
+                                estadoService.findAll(), vehiculoService);
 		dlg.setVisible(true);
 		if (!dlg.isConfirmed()) {
 			return;

--- a/controller/ShowVehiculoCreateAction.java
+++ b/controller/ShowVehiculoCreateAction.java
@@ -24,7 +24,8 @@ public class ShowVehiculoCreateAction extends AbstractCreateAction<VehiculoDTO, 
 
         @Override
         protected VehiculoCreateDialog createDialog() {
-                return new VehiculoCreateDialog(frame, categoriaService.findAll(), estadoService.findAll());
+                return new VehiculoCreateDialog(frame, categoriaService.findAll(),
+                                estadoService.findAll(), vehiculoService);
         }
 
         @Override

--- a/controller/ShowVehiculoEditAction.java
+++ b/controller/ShowVehiculoEditAction.java
@@ -27,8 +27,8 @@ public class ShowVehiculoEditAction {
 		if (dto == null) {
 			return;
 		}
-		VehiculoEditDialog dlg = new VehiculoEditDialog(frame, dto, categoriaService.findAll(),
-				estadoService.findAll());
+                VehiculoEditDialog dlg = new VehiculoEditDialog(frame, dto, categoriaService.findAll(),
+                                estadoService.findAll(), vehiculoService);
 		dlg.setVisible(true);
 		if (dlg.isConfirmed()) {
 			vehiculoService.update(dlg.getVehiculo(), null);

--- a/controller/VehiculoSearchController.java
+++ b/controller/VehiculoSearchController.java
@@ -239,8 +239,8 @@ public class VehiculoSearchController {
 
 	public void onNuevoVehiculo() {
 		try {
-			VehiculoCreateDialog dlg = new VehiculoCreateDialog(frame, categoriaService.findAll(),
-					estadoService.findAll());
+                        VehiculoCreateDialog dlg = new VehiculoCreateDialog(frame, categoriaService.findAll(),
+                                        estadoService.findAll(), vehiculoService);
 			dlg.setVisible(true);
 			if (!dlg.isConfirmed()) {
 				return;

--- a/middleware_src/src/com/pinguela/rentexpres/model/TipoUsuarioDTO.java
+++ b/middleware_src/src/com/pinguela/rentexpres/model/TipoUsuarioDTO.java
@@ -23,4 +23,9 @@ public class TipoUsuarioDTO extends ValueObject {
     public void setNombreTipo(String nombreTipo) {
         this.nombreTipo = nombreTipo;
     }
+
+    @Override
+    public String toString() {
+        return nombreTipo != null ? nombreTipo : "";
+    }
 }

--- a/renderer/VehiculoActionsCellEditor.java
+++ b/renderer/VehiculoActionsCellEditor.java
@@ -54,7 +54,7 @@ public class VehiculoActionsCellEditor extends AbstractActionsCellEditor {
                                                 List<EstadoVehiculoDTO> estados = searchAction != null ? searchAction.getEstadoService().findAll() : java.util.Collections.emptyList();
                                                 List<CategoriaVehiculoDTO> categorias = searchAction != null ? searchAction.getCategoriaService().findAll() : java.util.Collections.emptyList();
 
-						VehiculoEditDialog dlg = new VehiculoEditDialog(frame, vehiculoActual, categorias, estados);
+                                                VehiculoEditDialog dlg = new VehiculoEditDialog(frame, vehiculoActual, categorias, estados, service);
 						dlg.setVisible(true);
 
 						if (dlg.isConfirmed()) {

--- a/view/UsuarioTablePanel.java
+++ b/view/UsuarioTablePanel.java
@@ -46,7 +46,7 @@ public class UsuarioTablePanel extends JPanel {
 
     public void setModel(UsuarioSearchTableModel m) {
         table.setModel(m);
-        int[] widths = { 40, 100, 100, 100, 150, 100, 100, 120 };
+        int[] widths = { 40, 120, 120, 120, 200, 120, 120, 150 };
         for (int i = 0; i < widths.length && i < table.getColumnCount(); i++) {
             table.getColumnModel().getColumn(i).setPreferredWidth(widths[i]);
         }


### PR DESCRIPTION
## Summary
- show readable names for user types
- widen usuario table columns for better readability
- allow selecting vehicle brand and model from lists when creating or editing
- reload models when brand changes

## Testing
- `./build_middleware.sh`

------
https://chatgpt.com/codex/tasks/task_e_68548dd5ee448331b4d9716a6d25a108