### PR TITLE
Allow creating cliente from reserva dialog

### DIFF
--- a/dialog/ReservaCreateDialog.java
+++ b/dialog/ReservaCreateDialog.java
@@ -8,6 +8,7 @@ import java.awt.Frame;
 import net.miginfocom.swing.MigLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.text.SimpleDateFormat;
 import java.util.List;
 
 import javax.swing.DefaultComboBoxModel;
@@ -25,8 +26,13 @@ import com.pinguela.rentexpres.desktop.util.AppContext;
 import com.pinguela.rentexpres.desktop.util.SwingUtils;
 import com.pinguela.rentexpres.model.EstadoReservaDTO;
 import com.pinguela.rentexpres.model.ReservaDTO;
+import com.pinguela.rentexpres.model.ClienteDTO;
 import com.pinguela.rentexpres.service.EstadoReservaService;
 import com.pinguela.rentexpres.service.impl.EstadoReservaServiceImpl;
+import com.pinguela.rentexpres.service.ClienteService;
+import com.pinguela.rentexpres.service.impl.ClienteServiceImpl;
+import com.pinguela.rentexpres.exception.RentexpresException;
+import com.pinguela.rentexpres.desktop.dialog.ClienteCreateDialog;
 import com.toedter.calendar.JDateChooser;
 
 /**
@@ -42,8 +48,11 @@ public class ReservaCreateDialog extends JDialog implements ConfirmDialog<Reserv
 	protected final JDateChooser dcFin = new JDateChooser();
 	protected final JComboBox<EstadoReservaDTO> cmbEst = new JComboBox<>();
 
-	public final JButton btnCrear = new JButton("Crear");
-	public final JButton btnCancelar = new JButton("Cancelar");
+        public final JButton btnCrear = new JButton("Crear");
+        public final JButton btnCancelar = new JButton("Cancelar");
+        private final JButton btnNuevoCliente = new JButton("Nuevo Cliente");
+
+        private final ClienteService clienteService = new ClienteServiceImpl();
 
         private final EstadoReservaService estadoService = new EstadoReservaServiceImpl();
 
@@ -64,7 +73,8 @@ public class ReservaCreateDialog extends JDialog implements ConfirmDialog<Reserv
                 form.add(new JLabel("Vehículo ID:"), "cell 0 0");
                 form.add(txtVeh, "cell 1 0,growx");
                 form.add(new JLabel("Cliente ID:"), "cell 2 0");
-                form.add(txtCli, "cell 3 0,growx");
+                form.add(txtCli, "cell 3 0,growx,split 2");
+                form.add(btnNuevoCliente, "cell 3 0");
 
                 // Fila 1
                 form.add(new JLabel("Fecha Inicio:"), "cell 0 1");
@@ -80,18 +90,24 @@ public class ReservaCreateDialog extends JDialog implements ConfirmDialog<Reserv
 		buttons.add(btnCrear);
 		buttons.add(btnCancelar);
 
-		btnCrear.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				onCrear();
-			}
-		});
-		btnCancelar.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				dispose();
-			}
-		});
+                btnCrear.addActionListener(new ActionListener() {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                                onCrear();
+                        }
+                });
+                btnCancelar.addActionListener(new ActionListener() {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                                dispose();
+                        }
+                });
+                btnNuevoCliente.addActionListener(new ActionListener() {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                                abrirNuevoCliente();
+                        }
+                });
 
 		Container cp = getContentPane();
 		cp.setLayout(new BorderLayout(8, 8));
@@ -136,7 +152,14 @@ public class ReservaCreateDialog extends JDialog implements ConfirmDialog<Reserv
 
         private ReservaDTO buildFromForm1() {
                 ReservaDTO dto = new ReservaDTO();
-                // … resto de campos …
+                dto.setIdVehiculo(Integer.parseInt(txtVeh.getText().trim()));
+                dto.setIdCliente(Integer.parseInt(txtCli.getText().trim()));
+                dto.setFechaInicio(new SimpleDateFormat("yyyy-MM-dd").format(dcInicio.getDate()));
+                dto.setFechaFin(new SimpleDateFormat("yyyy-MM-dd").format(dcFin.getDate()));
+                EstadoReservaDTO est = (EstadoReservaDTO) cmbEst.getSelectedItem();
+                if (est != null) {
+                        dto.setIdEstadoReserva(est.getId());
+                }
                 if (AppContext.getCurrentUser() != null) {
                         dto.setIdUsuario(AppContext.getCurrentUser().getId());
                 }
@@ -169,6 +192,24 @@ public class ReservaCreateDialog extends JDialog implements ConfirmDialog<Reserv
         @Override
         public ReservaDTO getValue() {
                 return getReserva();
+        }
+
+        private void abrirNuevoCliente() {
+                ClienteCreateDialog dlg = new ClienteCreateDialog((Frame) getOwner());
+                dlg.setVisible(true);
+                if (dlg.isConfirmed()) {
+                        try {
+                                ClienteDTO nuevo = dlg.getCliente();
+                                if (clienteService.create(nuevo)) {
+                                        txtCli.setText(String.valueOf(nuevo.getId()));
+                                        JOptionPane.showMessageDialog(this,
+                                                        "Cliente creado con ID: " + nuevo.getId(),
+                                                        "Éxito", JOptionPane.INFORMATION_MESSAGE);
+                                }
+                        } catch (RentexpresException ex) {
+                                SwingUtils.showError(this, "Error creando cliente: " + ex.getMessage());
+                        }
+                }
         }
 
 	public boolean validar() {


### PR DESCRIPTION
## Summary
- add 'Nuevo Cliente' button to `ReservaCreateDialog`
- implement building `ReservaDTO` from form data
- hook up action to open `ClienteCreateDialog` and auto-fill cliente ID

## Testing
- `./build_middleware.sh`

------
https://chatgpt.com/codex/tasks/task_e_68548e9d76ec833196ba3d92f50f08bc